### PR TITLE
Adding image labels and publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Nix
+result
+# Created by https://www.gitignore.io/api/vim,osx,archives
+# Edit at https://www.gitignore.io/?templates=vim,osx,archives
+
+### Archives ###
+# It's better to unpack these files and commit the raw source because
+# git has its own built in compression methods.
+*.7z
+*.jar
+*.rar
+*.zip
+*.gz
+*.tgz
+*.bzip
+*.bz2
+*.xz
+*.lzma
+*.cab
+
+# Packing-only formats
+*.iso
+*.tar
+
+# Package management formats
+*.dmg
+*.xpi
+*.gem
+*.egg
+*.deb
+*.rpm
+*.msi
+*.msm
+*.msp
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+# End of https://www.gitignore.io/api/vim,osx,archives

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,31 @@
+# Publishing
+
+This is how we currently publish images to dockerhub
+
+## Steps
+
+1. Create your `auth.json` either manually or using `docker login`. Below we'll set this up manually:
+
+```
+~$ echo -n 'sarcasticadmin:mysupersecretpassword' | base64
+c2FyY2FzdGljYWRtaW46bXlzdXBlcnNlY3JldHBhc3N3b3Jk
+
+~$ cat << EOF > auth.json
+{
+        "auths": {
+                "https://index.docker.io/v1/": {
+                        "auth": "c2FyY2FzdGljYWRtaW46bXlzdXBlcnNlY3JldHBhc3N3b3Jk"
+                }
+        }
+}
+~$ export REGISTRY_AUTH_FILE=$(pwd)/auth.json
+```
+
+2. Setup your nix-shell and publish the image that you just built. Example publishing `awsutils`:
+
+```
+~$ nix-shell
+~$ ./publish-imgs awsutils
+```
+
+3. Done! It's now up in https://hub.docker.com/repositories/nebulaworks 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Nebulaworks Engineering use of [nixpkgs](https://github.com/NixOS/nixpkgs)
 ## Table of Contents
 
 * [Container Images](./imgs/README.md)
+* [Publishing](./PUBLISHING.md)

--- a/imgs/README.md
+++ b/imgs/README.md
@@ -3,3 +3,5 @@
 The goal of this project is to have a way to define and pin the inputs of an image (nixpkgs)
 so that the output of the image is `ALWAYS` reproducible. This has been a long shortcomming
 of docker images and `Dockerfile`.
+
+All images are currently hosted in on Dockerhub: https://hub.docker.com/u/nebulaworks

--- a/imgs/awsutils/default.nix
+++ b/imgs/awsutils/default.nix
@@ -1,14 +1,16 @@
 { system ? builtins.currentSystem }:
 
 let
+  nwi = import ../../nwi.nix;
   pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
-
-in pkgs.dockerTools.buildImage {
-  name = "nebulaworks/awsutils";
-  # Doesnt matter since we will use the derivation
-  # when publishing to image registry
-  tag = "latest";
+  lib = pkgs.lib;
   contents = [ pkgs.coreutils pkgs.bash pkgs.jq pkgs.curl pkgs.awscli ];
+in pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/awsutils";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
   extraCommands = ''
       # make sure /tmp exists
       mkdir -m 1777 tmp
@@ -17,6 +19,11 @@ in pkgs.dockerTools.buildImage {
     Env = [ 
       "PATH=/bin/"
     ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x )));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    }; 
     WorkingDir = "/";
   };
 }

--- a/nwi.nix
+++ b/nwi.nix
@@ -1,0 +1,5 @@
+{
+  company = "Nebulaworks Inc.";
+  homepage = "https://nebulaworks.com/";
+  source = "https://github.com/Nebulaworks/nix-garage";
+}

--- a/pin/pins/nixos-unstable_0.json
+++ b/pin/pins/nixos-unstable_0.json
@@ -1,0 +1,9 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs-channels.git",
+  "rev": "b61999e4ad60c351b4da63ae3ff43aae3c0bbdfb",
+  "date": "2020-04-16T12:43:36Z",
+  "sha256": "0cggpdks4qscyirqwfprgdl91mlhjlw24wkg0riapk5f2g2llbpq",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/publish-imgs
+++ b/publish-imgs
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# vim: ft=sh sw=2 et
+# shellcheck shell=bash
+set -efo pipefail
+
+test -z $1 && (echo "pass in img" && exit 1)
+
+IMG_DIR="imgs/$1"
+
+# Make sure nix-build was run
+test -f ${IMG_DIR}/result || (echo "please build derivation" && exit 1)
+
+derivation=$(nix show-derivation $(nix-instantiate ${IMG_DIR}/default.nix))
+registry="docker.io"
+image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
+org=$(echo $image_fullname | cut -d '/' -f 1)
+image_name=$(echo $image_fullname | cut -d '/' -f 2)
+calcout=$(echo $derivation | jq '.[] | .env.out')
+calcout=$(basename ${calcout} | cut -d '-' -f1)
+registry_endpoint="${registry}/${org}/${image_name}:${calcout}"
+
+# Check if this image is already in the registry
+skopeo inspect docker://${registry_endpoint} && exit 0
+
+skopeo copy docker-archive:result docker://${registry_endpoint}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import ./pin { snapshot = "nixos-20-03_0"; };
+with import ./pin { snapshot = "nixos-unstable_0"; };
 
 mkShell {
   buildInputs = [


### PR DESCRIPTION
## Description

There is no way to take the existing `awsutils` container and cleanly publish it to a registry. Additionally since we are using the derivations for the image tags we have no way of identifying what versions of pkgs are contained in the container without running it.

## New Behavior
* image push script
* adding unstable pin to use the newest version of skopeo
* pkg versions be included in image as label: `com.nebulaworks.packages`

## Tests

Current `awsutils` image published to our dockerhub registry:
```
$ skopeo inspect docker://docker.io/nebulaworks/awsutils:dz783iaashdby6phqf9pcydxsw1bbjq0
{
    "Name": "docker.io/nebulaworks/awsutils",
    "Digest": "sha256:4df34c1e6ab561b3aa6f0c250122ce121ff18e6803d72733f041978b87979df4",
    "RepoTags": [
        "dz783iaashdby6phqf9pcydxsw1bbjq0"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "awscli:1.17.13,bash:4.4,coreutils:8.31,curl:7.68.0,jq:1.6",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:6f29a11d541b258cbfb4956ccc442ac0ecf8a6c052f10d1ed0d6d6078ae30f2a"
    ],
    "Env": [
        "PATH=/bin/"
    ]
}
```