### PR TITLE
[READY] Added LiveCD Configuration for Yubikey NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ Nebulaworks Engineering use of [nixpkgs](https://github.com/NixOS/nixpkgs)
 
 * [Container Images](./imgs/README.md)
 * [Publishing](./PUBLISHING.md)
+* [iso Configs](./isos/README.md)
+
+## Building Nix Configurations
+While there are numerous ways of building Nix configurations, one way to build nix configs in a non-linux environment is leveraging a Docker container. The general command for this approach is:
+```
+docker run --rm -it -v $(git rev-parse --show-toplevel):/build -w /build <nixDockerImage>@sha256<imageSHA256> /bin/sh
+```
+
+Command notes:
+- Mounts a shared volume from the project's root with a new folder in the container, `/build`, allowing for the contents of the container to be shared with the host and vice verse
+- `nixDockerImage` is a Docker image that has the `nix` commands preinstalled. [This](https://hub.docker.com/r/nixos/nix) is one such image that can be used.
+- `imageSHA256` is the Docker image's digest, which safely pins the image to a specific version.

--- a/isos/README.md
+++ b/isos/README.md
@@ -1,0 +1,6 @@
+# Generating NixOS isos
+
+This folder contains directories containing specific `.nix` configurations that allow for the generation of an `.iso` of a specific NixOS environment.
+
+## Table of Contents
+* [Yubikey ISO](./yubikey/README.mc)

--- a/isos/yubikey/README.md
+++ b/isos/yubikey/README.md
@@ -1,0 +1,50 @@
+# NixOS LiveCD Configuration
+
+The files in this directory pertain to the generation of an `.iso` that can be utilized to interact with the Yubikey.
+
+## Table of Contents
+1. [Overview](#Overview)
+2. [Requirements](#Requirements)
+2. [Usage](#Usage)
+3. [References](#References)
+
+## Overview
+This NixOS liveCD configuration is utilized to create a standard `.iso` that can be easily used to interact with the Yubikey. This image is configured to be airgapped as possible, while containing all of the tools necessary for our usage. While there are numerous ways to load the `.iso` onto a computer, the safest and easiest way is to use a Virtual Machine, since those are easily disposable and prevents any data leakage onto the host computer.
+
+## Requirements
+- Docker
+- A Virtual Machine software (this guide will use [VirtualBox](https://www.virtualbox.org/))
+
+## Usage
+1. Clone down this repository and navigate to the repo's root directory
+2. In a local terminal, run the following command, which will generate the `.iso` and output it to the root directory of this repo.
+    - The docker hub image (pinned via digest at `2.3`) that's used can be found [here](https://hub.docker.com/r/nixos/nix).
+    - The nixpkgs channel (pinned at `20.03`) that's used can be found [here](https://channels.nixos.org/).
+```
+docker run --rm -it -v $(git rev-parse --show-toplevel):/build -w /build nixos/nix@sha256:af330838e838cedea2355e7ca267280fc9dd68615888f4e20972ec51beb101d8 /bin/sh -c "\
+    nix-channel --add https://channels.nixos.org/nixos-20.03 nixpkgs &&\
+    nix-channel --update &&\
+    nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=isos/yubikey/default.nix --out-link installer &&\
+    cp ./installer/iso/*.iso . \
+    "
+```
+> This may take 5-10 mins depending on how large the image is. 
+3. Using a virtual machine software, create a new VM with the `.iso` that was extracted in the last step
+    - Select `new` and fill in the parameters with these values:
+        - Type: `Linux`
+        - Version: `Linux 2.6 / 3.x / 4.x (64-bit)`
+    - Set the memory to be `4096 MBs`
+        - This can be adjusted according to how large the `iso` is.
+    - Opt out on the `Create Virtual Hard Drive`
+    - Select the new VM and under `Settings` , navigate to `Storage`, and select the first `Optical Drive`
+    - Select the blue CD icon and find the `iso` that was just created
+    - Select `OK` and boot up the VM by selecting `Start`
+    - Wait a few mins (the screen will show a terminal view followed by a black screen; this is normal) until the Desktop shows up
+4. Done! The VM can now be used as if the `iso` was loaded via a USB
+
+## References
+- [Docker image for NixOS building](https://github.com/NixOS/docker)
+- [Yubikey Wiki Page in NixOS](https://nixos.wiki/wiki/Yubikey)
+- [Yubikey Guide](https://github.com/drduh/YubiKey-Guide/blob/master/README.md)
+- [Sample NixOS liveCD config](https://github.com/dhess/nixos-yubikey)
+- [Blog Post describing NixOS iso creation](https://thomashartmann.dev/blog/building-a-custom-nixos-installer/)

--- a/isos/yubikey/default.nix
+++ b/isos/yubikey/default.nix
@@ -1,0 +1,103 @@
+# NixOS liveCD configuration to generate an iso to interact with Yubikey
+# To build the iso: 
+# nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=default.nix --out-link installer
+
+{ config, pkgs, ... }:
+
+with pkgs; {
+    # Utilizing the bare minimum version in this case. Can also use the graphical version as well
+    # Also adds in the specific nix-channel that was used to build the iso into the iso, just in case if ad-hoc packages are needed.
+    imports = [ 
+      <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix>
+      <nixpkgs/nixos/modules/installer/cd-dvd/channel.nix>
+    ];
+
+    # Installs all necessary packages for the iso
+    environment.systemPackages = [ 
+      # Pre-req Packages
+      gnupg 
+      pinentry-curses 
+      pinentry-qt 
+      paperkey 
+      wget
+      pcsctools
+      pcsclite
+      cryptsetup
+      pwgen
+
+      # Yubikey Packages
+      yubikey-manager
+      yubikey-personalization
+      yubico-piv-tool
+      
+      # CA packages
+      autoconf
+      automake
+      libtool
+      pkg-config
+      check
+      gengetopt
+      help2man
+      openssl      
+    ];
+
+    # Adds the user to be able to access the yubikey
+    services.udev.packages = [ 
+        yubikey-personalization 
+    ];
+
+    # Enables the smart card mode of the Yubikey
+    services.pcscd.enable = true;
+
+    # Sets the root user to have an empty password
+    services.mingetty.helpLine = "The 'root' account has an empty password.";
+    users.extraUsers.root.initialHashedPassword = "";
+
+    # Makes sure that all data is written to ram and not persistently stored
+    boot.kernelParams = [ 
+        "copytoram" 
+    ];
+
+    # Defaults to make sure everything in here is secured
+    boot.cleanTmpDir = true;
+    boot.kernel.sysctl = {
+        "kernel.unprivileged_bpf_disabled" = 1;
+    };
+
+    # Air-gapped system
+    boot.initrd.network.enable = false;
+    networking.dhcpcd.enable = false;
+    networking.dhcpcd.allowInterfaces = [];
+    networking.firewall.enable = true;
+    networking.useDHCP = false;
+    networking.useNetworkd = false;
+    networking.wireless.enable = false;
+
+    # Allows Yubukey to have SSH and GPG authentication
+    programs = {
+        ssh.startAgent = false;
+        gnupg.agent = {
+            enable = true;
+            enableSSHSupport = true;
+        };
+    };
+
+    # Sets up the shell to have an environment variable that creates the directory for all generated keys
+    # Also utilizes a preconfigured gpg config and configures a gpg-agent config.
+    environment.interactiveShellInit = ''
+        export GNUPGHOME=/run/user/$(id -u)/gnupghome
+        if [ ! -d $GNUPGHOME ]; then
+        mkdir $GNUPGHOME
+        fi
+        sudo cp ${pkgs.fetchurl {
+            url = "https://raw.githubusercontent.com/drduh/config/662c16404eef04f506a6a208f1253fee2f4895d9/gpg.conf";
+            sha256 = "118fmrsn28fz629y7wwwcx7r1wfn59h3mqz1snyhf8b5yh0sb8la";
+        }} "$GNUPGHOME/gpg.conf"
+        sudo cat << EOF > $GNUPGHOME/gpg-agent.conf
+        pinentry-program /run/current-system/sw/bin/pinentry-curses
+        EOF
+        sudo chown nixos:users $GNUPGHOME/gpg-agent.conf
+        sudo chmod 644 $GNUPGHOME/gpg-agent.conf
+        echo "\$GNUPGHOME has been set up for you. Generated keys will be in $GNUPGHOME."
+    '';
+}


### PR DESCRIPTION
# Overview
This PR adds the following functionality to the repository:
- A `.nix` config that defines all of the requirements Nebulaworks needs to create a Yubikey NixOS image.
- A `README.md` that documents out the process for making the LiveCD.

# Tests
- Verified that the image can be created via the command outlined in the `README.md`
- Used VM software to boot up the `.iso` and confirmed all needed packages are on the image.