### PR TITLE
[READY] Adding flasksample pkg and toplevel default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+rec {
+  flasksample = pkgs.callPackage ./pkgs/flasksample {};
+}

--- a/pkgs/flasksample/default.nix
+++ b/pkgs/flasksample/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "flasksample";
+  version = "0.0.1";
+
+  # This is on my own fork but will bring this into NWI org in a followup
+  src = fetchFromGitHub {
+    owner  = "sarcasticadmin";
+    rev    = "1edd490a7d36727d2f9b0846fd3536f7b1baba45";
+    repo   = "flaskapp";
+    sha256 = "1dmmg79lp0dr2sy9drrpj7k1bbs53awwqqckdyfjxvl0fj7pfmkb";
+  };
+
+  propagatedBuildInputs = [ python3Packages.flask ];
+
+  meta = with lib; {
+    description = "Simple flask application for testing web requests";
+    license = licenses.bsd3;
+    maintainers = "NWI";
+  };
+}


### PR DESCRIPTION
## Description

Adding `flasksample` derivation for use and testing of http endpoints. Leveraging a branch from the fork of https://github.com/sjeeva/flaskapp. Will eventually move this into a more perment location within the NWI org.

## Acceptance Criteria
* Able to build the `flasksample` derivation with `nix-build`
* Able to run flask application inside temporary nix-shell:

```
~$ nix-shell -p "with import ./default.nix {}; flasksample"
```

Inside nix-shell:

```
[nix-shell:~/nix-garage]$ export FLASK_APP=flasksample.app

[nix-shell:~/nix-garage]$ flask run &
[1] 4503

[nix-shell:~/nix-garage]$  * Serving Flask app "flasksample.app"
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)

[nix-shell:~/nix-garage]$ curl http://127.0.0.1:5000/ 
127.0.0.1 - - [27/May/2020 00:48:55] "GET / HTTP/1.1" 200 -
<html><head><title>Docker + Flask Demo</title></head><body><table><tr><td> Start Time </td> <td>2020-May-27 00:48:48</td> </tr><tr><td> Hostname </td> <td>ubuntu-bionic</td> </tr><tr><td> Local Address </td> <td>127.0.1.1</td> </tr><tr><td> Remote Address </td> <td>127.0.0.1</td> </tr><tr><td> Server Hit </td> <td>1</td> </tr></table></body></html>
[nix-shell:~/nix-garage]$ curl http://127.0.0.1:5000/ 
127.0.0.1 - - [27/May/2020 00:48:56] "GET / HTTP/1.1" 200 -
<html><head><title>Docker + Flask Demo</title></head><body><table><tr><td> Start Time </td> <td>2020-May-27 00:48:48</td> </tr><tr><td> Hostname </td> <td>ubuntu-bionic</td> </tr><tr><td> Local Address </td> <td>127.0.1.1</td> </tr><tr><td> Remote Address </td> <td>127.0.0.1</td> </tr><tr><td> Server Hit </td> <td>2</td> </tr></table></body></html>
[nix-shell:~/nix-garage]$ kill 4503
```
```
