### PR TITLE
[READY] - Adding cacert pkg to awsutils img

### DIFF
--- a/imgs/awsutils/default.nix
+++ b/imgs/awsutils/default.nix
@@ -3,7 +3,7 @@ let
   nwi = import ../../nwi.nix;
   pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
   lib = pkgs.lib;
-  contents = [ pkgs.coreutils pkgs.bash pkgs.jq pkgs.curl pkgs.awscli ];
+  contents = with pkgs; [ cacert coreutils bash jq curl awscli ];
 in
 pkgs.dockerTools.buildImage {
   inherit contents;
@@ -18,6 +18,7 @@ pkgs.dockerTools.buildImage {
   config = {
     Env = [
       "PATH=/bin/"
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
     ];
     Labels = {
       "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));


### PR DESCRIPTION
`curl` isnt very useful if you dont have a certificate authority. Got the follow error due to no ca trusts being present:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```