### PR TITLE
[READY] Fixed workflows to utilize proper checkout parameters

### DIFF
--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -18,8 +18,13 @@ jobs:
       image: nixos/nix@sha256:af330838e838cedea2355e7ca267280fc9dd68615888f4e20972ec51beb101d8
 
     steps:
+        # Checks out repository to docker container
+        # Utilizes the commit from the open PR
+        # Using SHA v2
       - name: Pulls Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@28c7f3d2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       
         # Parses through all nix files using nixpkgs-fmt, outputting the diff
         # between the modded one and original if one of the new nix configs are not properly formatted

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -2,7 +2,7 @@
 
 ### Workflow
 # 1. We want this to be ran manually i.e. with a comment in a PR. To do this, we can have a release process where we update what is currently out in prod via a PR
-# 2. Once the PR is made, we then have someone (who is an approver) comment in the PR "Publish Images" (WIP)
+# 2. Once the PR is made, we then have someone (who is an approver) comment in the PR "Publish Images"
 # 3. GitHub Actions will detect this comment being made, and check if the comment was made by an approved person, alongside what they commented.
 # 4. If it matches, we fire off this job, where we log into docker.io with nwiauto (also pass in the password via a secret declared in the repo)
 # 5. Once we logged in, we then execute the script "publish-imgs", which will publish the image passed into it.
@@ -24,12 +24,15 @@ jobs:
     if: > 
       startsWith(github.event.comment.body, 'publish')
       && startsWith(github.event.issue.pull_request.url, 'https://')
+
+    # Upon completion, this step will output a success status and the commit SHA of the PR's head commit.
     outputs:
       status: ${{ steps.verify.outputs.status }}
+      sha: ${{ steps.verify.outputs.sha }}
     
     steps:
-      # Verifies if the commenter is an approver, otherwise, the job will output an error
-      - name: Verify that Commenter is Approver
+      # Verifies if commenter is approver, in which it will extract PR's head commit sha
+      - name: Verify Commenter is Approver
         id: verify
         run: |
           set -x
@@ -38,9 +41,17 @@ jobs:
           --header 'Authorization: Bearer ${{ secrets.NWIAUTO_PAT }}' \
           --header 'Content-Type: application/json' | jq -r '.state' \
           )
+          commit_sha=$(curl -sSf \
+          --url ${{ github.event.issue.pull_request.url }} \
+          --header 'Authorization: Bearer ${{ secrets.NWIAUTO_PAT }}' \
+          --header 'Content-Type: application/json' | jq -r '.head.sha' \
+          )
 
-          if [ $is_approver == "active" ]; then
+          if [[ $is_approver == "active" ]] && [[ ! -z $commit_sha ]]; then
             echo ::set-output name=status::success
+            echo ::set-output name=sha::$commit_sha
+          elif [ -z $commit_sha ]; then
+            echo ::set-output name=status::invalidsha
           else
             echo ::set-output name=status::failure
           fi
@@ -62,8 +73,12 @@ jobs:
     
     steps:
       # Checks out repository to docker container
+      # Utilizes the commit from the open PR, which was gotten from the previous step
+      # Using SHA v2
       - name: Pulls Repository Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@28c7f3d2
+        with:
+          ref: ${{ needs.verify.outputs.sha }}
 
       # Attempt to authenticatie to Docker hub and publish all images
       - name: Authenticate and Execute Publish Script
@@ -92,7 +107,7 @@ jobs:
             fi
 
             nix-shell --run "cd ./imgs/$currImgName && nix-build"
-            cp $GITHUB_WORKSPACE/imgs/$currImgName/result $GITHUB_WORKSPACE/result
+            cp $currImgPath/result $GITHUB_WORKSPACE/result
             nix-shell --run "./publish-imgs $currImgName"
           done
           echo ::set-output name=allImgs::$allImgs
@@ -104,6 +119,18 @@ jobs:
     needs: [verify, publish]
 
     steps:
+      # Creates PR comment telling commentor that there was an issue with the commit SHA for the PR 
+      - name: Create Faulure PR Comment for Invalid Commit SHA
+        if: needs.verify.outputs.status == 'invalidsha'
+        uses: jungwinter/comment@5acbb   # SHA ref v1.0.2
+        with:
+          type: create
+          body: |
+            Hm, there was an issue with the commit SHA used to obtain the repository. 
+            Please verify the commit SHA used: `${{ needs.verify.outputs.sha }}`
+          token: ${{ secrets.NWIAUTO_PAT }}
+          issue_number: ${{ github.event.issue.number }}
+        continue-on-error: false
 
       # Creates a PR comment telling commenter to ask an approved user to pubish images
       - name: Create Failure PR Comment for Verifying


### PR DESCRIPTION
## Summary
This PR fixes an issue with the workflow files in that they were missing a key parameter to make sure that they were pulling code from the _PR_, not from the default branch. Also, some minor clean up was done on the workflow files in order to keep consistency as well as clarity.

Note: The `lint-nixpkgs` job still worked as intended because it was using a PR event, which the default action for `actions/checkout` in that case is to use the PR's head commit. This isn't the case for the `publish_imgs`, which uses an issue_comment event. As such, to keep consistency, the `lint_nixpkgs` is also modified to reflect the specific usage of a branch SHA.

## Authentication Fix Explanation
The issue of the authentication error comes from the context that the event was running from. Because of the default behavior of `actions/checkout@v2` as well as the event being used coming from an `issue_comment`, the context used was not the base repository, but instead, the context of the forked branch. As such, secrets are not passed in that fork context, despite the workflow job running in the base repository. 

The fix for this was to extract the SHA of the PR's head commit, which will take the work that was made from the PR, but allowing for the use of secrets declared in the base repository. This behavior can be seen in [this PR](https://github.com/maishiroma/GitGoodActons/pull/6) and in this successful [job](https://github.com/maishiroma/GitGoodActons/runs/828067713?check_suite_focus=true). Note that the workflow in that repository is using a SHA ref to the PR.

## Tests
- Verified in my own environment of changes:
  - [PR used](https://github.com/maishiroma/GitGoodActons/pull/5)
  - [Successful Job](https://github.com/maishiroma/GitGoodActons/runs/824476203?check_suite_focus=true), noting the steps in `Verify Commentor is Approver` and `Authenticate and Execute Publish Script`