### PR TITLE
[READY] Using actual secret ref

### DIFF
--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -89,7 +89,7 @@ jobs:
           {
             "auths": {
               "https://index.docker.io/v1/": {
-                "auth": "$(echo -n 'nwiauto:${{ secrets.USER_PASSWORD }}' | base64)"
+                "auth": "$(echo -n 'nwiauto:${{ secrets.NWIAUTO_PASSWORD }}' | base64)"
               }
             }
           }


### PR DESCRIPTION
## Description

After noticing `publish` failures it looks like we were expecting the wrong secret credential. These was an oversight while testing some new features of our actions workflow. This should fix things.