### PR TITLE
[READY] Added config for magic-wormhole-mailbox

### DIFF
--- a/imgs/magic-wormhole-mailbox/README.md
+++ b/imgs/magic-wormhole-mailbox/README.md
@@ -1,0 +1,10 @@
+# Magic Wormhole Mailbox Server Docker Image
+This defines a lightweight `docker image` that automatically starts a self-hosted rendezvous server for a [magic-womhole service](https://github.com/warner/magic-wormhole-mailbox-server). 
+
+## Setup
+The rendezvous server can be accessed locally at `localhost:4000`:
+```
+$ docker container run --name mailbox -d -p 4000:4000 nebulaworks/magic-wormhole-mailbox-server:latest
+...
+$ magic-wormhole --relay-url=ws://localhost:4000/v1 ...
+```

--- a/imgs/magic-wormhole-mailbox/default.nix
+++ b/imgs/magic-wormhole-mailbox/default.nix
@@ -1,0 +1,37 @@
+{ system ? builtins.currentSystem }:
+let
+  nwi = import ../../nwi.nix;
+  pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
+  lib = pkgs.lib;
+  importedPythonPkgs = with pkgs; python37.withPackages (pythonPkgs: with pythonPkgs; [ magic-wormhole-mailbox-server ]);
+  contents = with pkgs; [ bash coreutils procps importedPythonPkgs ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/magic-wormhole-mailbox";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+
+    # Magic-Wormhole-Mailbox Directory
+    mkdir -p -m 1750 var/lib/magic-wormhole-mailbox
+  '';
+  config = {
+    Env = [
+      "PATH=/bin/"
+    ];
+    ExposedPorts = {
+      "4000/tcp" = {};
+    };
+    WorkingDir = "/var/lib/magic-wormhole-mailbox";
+    EntryPoint = [ "twist" "wormhole-mailbox" "--usage-db=usage.sqlite" "--port=tcp:4000" ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
This PR adds in a new `docker image` configuration that automatically sets up a self-hosted rendezvous server for a magic-wormhole service. 

## Benefit
Since there are little open sourced solutions to building consistent solutions in running self-hosted solutions, I think this can greatly help others see a working example of this and how they can implement this in their own solutions.

## Tests
- Build derivation successfully and imported docker image
- Ran container and tested service locally