### PR TITLE
[READY] Auto-Repo Creation via GitHub Workflow

### DIFF
--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -85,6 +85,12 @@ jobs:
         id: publish
         run: |
           set -x
+          cat << EOF > $GITHUB_WORKSPACE/data.json
+          {
+            "username": "nwiauto",
+            "password": "${{ secrets.NWIAUTO_PASSWORD }}"
+          }
+          EOF
           cat << EOF > $GITHUB_WORKSPACE/auth.json
           {
             "auths": {
@@ -94,6 +100,11 @@ jobs:
             }
           }
           EOF
+          
+          set +x
+          export DOCKER_HUB_TOKEN=$(nix-shell --run "curl -s -H 'Content-Type: application/json' -X POST \
+          -d @$GITHUB_WORKSPACE/data.json --url https://hub.docker.com/v2/users/login/ | jq -r .token")
+          set -x
           export REGISTRY_AUTH_FILE=$GITHUB_WORKSPACE/auth.json
 
           cd $GITHUB_WORKSPACE
@@ -108,7 +119,12 @@ jobs:
 
             nix-shell --run "cd ./imgs/$currImgName && nix-build"
             cp $currImgPath/result $GITHUB_WORKSPACE/result
-            nix-shell --run "./publish-imgs $currImgName"
+            
+            set +x
+            nix-shell --run "cd $GITHUB_WORKSPACE && \
+            ./create-repo $DOCKER_HUB_TOKEN nebulaworks $currImgName && \
+            ./publish-imgs $currImgName"
+            set -x
           done
           echo ::set-output name=allImgs::$allImgs
         continue-on-error: false

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -31,11 +31,16 @@ c2FyY2FzdGljYWRtaW46bXlzdXBlcnNlY3JldHBhc3N3b3Jk
 ~$ export REGISTRY_AUTH_FILE=$(pwd)/auth.json
 ```
 
-2. Setup your nix-shell and publish the image that you just built. Example publishing `awsutils`:
+2. Obtain a Docker Hub Token, which can be acheived from this `curl` command (replacing $UNAME and $UPASS with your own values):
+```
+export TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${UNAME}'", "password": "'${UPASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+```
 
+3. Setup your nix-shell and run both `create-repo` and `publish-imgs` scripts sequentially to publish the image that you just built. Example publishing `awsutils` under `nebulaworks` user:
 ```
 ~$ nix-shell
+~$ ./create-repo $TOKEN nebulaworks awsutils
 ~$ ./publish-imgs awsutils
 ```
 
-3. Done! It's now up in https://hub.docker.com/repositories/nebulaworks 
+4. Done! It's now up in https://hub.docker.com/repositories/nebulaworks 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Nebulaworks Engineering use of [nixpkgs](https://github.com/NixOS/nixpkgs)
 * [Container Images](./imgs/README.md)
 * [Publishing](./PUBLISHING.md)
 * [iso Configs](./isos/README.md)
+* [Templates](./templates/README.md)
 
 ## Building Nix Configurations
 While there are numerous ways of building Nix configurations, one way to build nix configs in a non-linux environment is leveraging a Docker container. The general command for this approach is:

--- a/create-repo
+++ b/create-repo
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# vim: ft=sh sw=2 et
+# shellcheck shell=bash
+set -efo pipefail
+
+# A Bash script that automates creating a Docker Hub Repository, if applicable. Also adds an org group, engineering, to have read/write access to said repo if applicable
+
+#### Requires the following parameters to be passed in from the CLI:
+# Docker Hub API Token = $1
+# User/Org name = $2
+# Repo name = $3
+
+# Checks if required values are passed in
+test -z $1 && (echo "Script needs a token towards Docker Hub!" && exit 1)
+test -z $2 && (echo "Script needs a user/org that exists in Docker Hub!" && exit 1)
+test -z $3 && (echo "Script needs a repo name to verify/use!" && exit 1)
+
+REPO_EXISTS_CODE=$(curl --write-out %{response_code} --output /dev/null -s \
+    -H "Content-Type: application/json" -H "Authorization: JWT $1" \
+    --url https://hub.docker.com/v2/repositories/$2/$3/)
+
+if [ $REPO_EXISTS_CODE -ne 200 ]; then
+    echo "Docker Hub repo $3 does not exist in $2, creating now..."
+    tmpdata=$(mktemp --suffix ".json" -t repo_data_XXXXXXX)
+    cat << EOF > $tmpdata
+{
+    "namespace": "$2",
+    "name": "$3",
+    "description": "$(sed '2q;d' ./imgs/$3/README.md)",
+    "is_private": false
+}
+EOF
+    curl -s -H "Content-Type: application/json" -H "Authorization: JWT $1" -X POST \
+    -d @$tmpdata --url https://hub.docker.com/v2/repositories/
+    echo
+
+    # Clean up temp data
+    rm $tmpdata
+else
+    echo "Repo $3 already exists in $2. Skipping rest of script (including org perms and README addition)."
+    exit 0
+fi
+
+# We only run these next lines of code if the repo did NOT exist at first 
+ORG_RESPONSE_CODE=$(curl -s --write-out %{response_code} --output /dev/null \
+    -H "Content-Type: application/json" -H "Authorization: JWT $1" \
+    --url https://hub.docker.com/v2/orgs/$2/groups/)
+    
+if [ $ORG_RESPONSE_CODE -eq 200 ]; then
+    echo "User is actually organization, attempting to add engineering group with read/write permissions in repo $3..."
+    ENG_GROUP_ID=$(curl -s -H "Content-Type: application/json" -H "Authorization: JWT $1" \
+    --url https://hub.docker.com/v2/orgs/$2/groups/ \
+    | jq -r '.results[] | select(.name == "engineering").id')
+    VERIFY_ENG_GROUP=$(curl -s -H "Content-Type: application/json" -H "Authorization: JWT $1" \
+    --url https://hub.docker.com/v2/repositories/$2/$3/groups/ | jq --argjson id $ENG_GROUP_ID \
+    '.results[] | select(.group_id == $id)')
+
+    if [ -z $VERIFY_ENG_GROUP ]; then 
+        # Docker API mentions that permissions for repos are cumulative, meaning write also implies read
+        # https://docs.docker.com/docker-hub/orgs/#permissions-reference
+        curl -s -H "Content-Type: application/json" -H "Authorization: JWT $1" -X POST \
+        -d "{\"group_id\": \"${ENG_GROUP_ID}\",\"permission\": \"write\"}" \
+        --url https://hub.docker.com/v2/repositories/$2/$3/groups/
+        echo
+    else
+        echo "There already exists engineering group with read/write permissions on repo $3"
+    fi
+else
+    echo "User is not organization, skipping adding group permissions..."
+fi
+
+# The passed in repo will have a new full_description associated with the README.md associated in the /img/image_name/
+echo "Adding ./imgs/$3/README.md to repo..."
+RESPONSE_CODE=$(curl -s -L --write-out %{response_code} --output /dev/null -H "Authorization: JWT $1" \
+    -X PATCH --data-urlencode full_description@./imgs/$3/README.md \
+    --url https://hub.docker.com/v2/repositories/$2/$3/)
+echo "Results: $RESPONSE_CODE"

--- a/imgs/awsutils/README.md
+++ b/imgs/awsutils/README.md
@@ -1,0 +1,5 @@
+# awsutils
+A lightweight container that has all neccessary tools for interacting with AWS.
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/helmsman-aws/README.md
+++ b/imgs/helmsman-aws/README.md
@@ -1,0 +1,5 @@
+# Helmsman-aws
+A containerized image that allows for the use of helmsman within AWS.
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/magic-wormhole-mailbox/README.md
+++ b/imgs/magic-wormhole-mailbox/README.md
@@ -1,5 +1,7 @@
 # Magic Wormhole Mailbox Server Docker Image
-This defines a lightweight `docker image` that automatically starts a self-hosted rendezvous server for a [magic-womhole service](https://github.com/warner/magic-wormhole-mailbox-server). 
+A containerized solution for deploying a rendezvous server for magic-wormhole
+
+This image defines a lightweight `docker image` that automatically starts a self-hosted rendezvous server for a [magic-womhole service](https://github.com/warner/magic-wormhole-mailbox-server). 
 
 ## Setup
 The rendezvous server can be accessed locally at `localhost:4000`:
@@ -8,3 +10,6 @@ $ docker container run --name mailbox -d -p 4000:4000 nebulaworks/magic-wormhole
 ...
 $ magic-wormhole --relay-url=ws://localhost:4000/v1 ...
 ```
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/shell.nix
+++ b/shell.nix
@@ -6,5 +6,6 @@ mkShell {
     jq
     skopeo
     nixpkgs-fmt
+    curl
   ];
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,10 @@
+# Repository Templates
+This directory contains useful templates that should be utilized when contributing new items to the `nix-garage`.
+
+## README_imgs.tpl Usage
+This is a template used to build the standard `README.md` that goes into the `imgs/image_name` directories. The `README.md` defined in there will be interpolated into the Docker Hub's repository for said image.
+
+### To set up:
+1. Copy `README_imgs.tpl` into a new image directory in `imgs/` and rename it to `README.md`
+2. Replace all areas that have `[X Here]` with the respected values and remove all initial `quoted` blocks
+3. Fill in the `README.md` like any other `README.md`, keeping in mind of the formatting of the bottom section as well as the __second line__ of the `README.md`

--- a/templates/README_imgs.tpl
+++ b/templates/README_imgs.tpl
@@ -1,0 +1,9 @@
+# [Title Here]
+[Short Description Here]
+> The above line is reservered for the image's `short_description` in Docker Hub. That block should be a short snippit of what the image is.
+
+[Main Content Here]
+> Everything else after the `[Short Description Here]` and before the `-----` can be anything.
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.


### PR DESCRIPTION
## Description
This PR continues to improve on the `publish-imgs` GitHub Action workflow by now auto-creating any new Docker Hub repository when a new image is being published for the first time.

In order to facilitate this workflow, the following new items are added to the repository:
1. A `templates/` directory which contains the following:
    - A `README_imgs.md`, which outlines a standardized `README` for all images made in this repository
    - A `README.md`, explaining the purpose and usage of the templates in that directory 
2. A new script, `create-repo`, which facilitates the creation of a new Docker Hub repo via API calls
    - This script also does the following:
      - Adds in the `engineering` group with `read/write` permissions
      - Adds in both a `short_description` and a `long_description`, with them being based on the `README_imgs.md` that will be in all `imgs/`

## Benefits
The biggest win for this PR is the ability for new images that are not yet existing in Nebulaworks Docker Hub to be pushed up without manual intervention on a Nebulaworks user to create a repository first. That small limitation slows down the publishing process, and with the current workflow we have in this repository, new images will have to get approved by a verified user, which helps prevent any unnecessary or malicious images to be published under Nebulaworks.

## Workflow changes
Other than having a soft requirement of needing all `imgs/` to have a README.md under the template as the `README_imgs.md`, from a CI perspective, nothing has changed.
  - The repo creation will be invoked during the CI build of `publish-imgs`, and will only actually create a repo if there does not exist one already.
  - For manually publishing images, the documentation for that has been modified accordingly. 

## Special Notes:
- The reason for parts of the `publish-imgs` now having `set +x` and `set -x` being encapsulated around code parts that are using the `DOCKER_HUB_TOKEN` is to prevent that value from being visible to anyone (since this is a public repository). While one alternative could be to modify the `create-repo` script to calculate the token, this script will be invoked X times (X = numb of images), which could lead to the script slowing down + being inefficient with its data. As such, only doing it once and passing in the token as a CLI argument was the most ideal way I found.
- With the standardization of the image READMEs, I also added in READMEs for all existing images that did not have one, making sure all of them abid by the new format.

## Tests
- Verified workflow in own [environment](https://github.com/maishiroma/GitGoodActons/pull/7)
- Specific GitHub Action [run](https://github.com/maishiroma/GitGoodActons/runs/871240418?check_suite_focus=true) that yielded the desired results.
- Verified that the org permissions work (WIP)