### PR TITLE
[READY] Added pki-validator Image

### DIFF
--- a/imgs/pki-validator/README.md
+++ b/imgs/pki-validator/README.md
@@ -1,0 +1,9 @@
+# pki-validator
+A Docker image containing useful tools for validating public key infrastructures.
+
+## Features
+- Lightweight image that allows for one to verify PKI easily
+- Can be used in a CI workflow to automate testing suites
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/pki-validator/default.nix
+++ b/imgs/pki-validator/default.nix
@@ -1,0 +1,30 @@
+{ system ? builtins.currentSystem }:
+let
+  nwi = import ../../nwi.nix;
+  pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
+  lib = pkgs.lib;
+  contents = with pkgs; [ openssl coreutils bash gnumake gnugrep gawk ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/pki-validator";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+  '';
+  config = {
+    Env = [
+      "PATH=/bin/"
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+    ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+    WorkingDir = "/";
+  };
+}


### PR DESCRIPTION
## Description
This PR adds in another Docker image to the repo, `pki-validator`. This image is designed to be used to run test cases with `openssl` and `make`.

## Tests
- [x] Validated image can be created via `nix-shell`
- [x] Validated that all needed packages are placed in configuration