### PR TITLE
fix help docstring for specifying a different branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Command notes:
 - Mounts a shared volume from the project's root with a new folder in the container, `/build`, allowing for the contents of the container to be shared with the host and vice verse
 - `nixDockerImage` is a Docker image that has the `nix` commands preinstalled. [This](https://hub.docker.com/r/nixos/nix) is one such image that can be used.
 - `imageSHA256` is the Docker image's digest, which safely pins the image to a specific version.
+
+### Contributing
+
+Please fork this repository and open a PR to contribute to this repository

--- a/pin/generate_pin
+++ b/pin/generate_pin
@@ -22,9 +22,13 @@ OPTIONS:
   -i      set iteration
 
 EXAMPLES:
-  Generate nix pin from nixos-20-03 branch:
+  Generate nix pin from nixos-20.03 branch:
 
-      $(basename "$0") nixos-20-03
+      $(basename "$0") nixos-20.03
+
+  Generate another iteration from nixos-20.03 branch:
+
+      $(basename "$0") -i "1" nixos-20.03
 
 EOF
 }


### PR DESCRIPTION
nixos branches use a `.` not at `-`. attempting to pin with the `-` fails

https://github.com/NixOS/nixpkgs-channels/tree/nixos-20.03