### PR TITLE
[READY] - Reworking default.nix and adding overlay

### DIFF
--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -84,7 +84,6 @@ jobs:
       - name: Authenticate and Execute Publish Script
         id: publish
         run: |
-          set -x
           cat << EOF > $GITHUB_WORKSPACE/data.json
           {
             "username": "nwiauto",
@@ -101,7 +100,6 @@ jobs:
           }
           EOF
           
-          set +x
           export DOCKER_HUB_TOKEN=$(nix-shell --run "curl -s -H 'Content-Type: application/json' -X POST \
           -d @$GITHUB_WORKSPACE/data.json --url https://hub.docker.com/v2/users/login/ | jq -r .token")
           set -x
@@ -117,9 +115,6 @@ jobs:
               allImgs="$allImgs, $currImgName"
             fi
 
-            nix-shell --run "cd ./imgs/$currImgName && nix-build"
-            cp $currImgPath/result $GITHUB_WORKSPACE/result
-            
             set +x
             nix-shell --run "cd $GITHUB_WORKSPACE && \
             ./create-repo $DOCKER_HUB_TOKEN nebulaworks $currImgName && \

--- a/README.md
+++ b/README.md
@@ -10,16 +10,56 @@ Nebulaworks Engineering use of [nixpkgs](https://github.com/NixOS/nixpkgs)
 * [Templates](./templates/README.md)
 
 ## Building Nix Configurations
-While there are numerous ways of building Nix configurations, one way to build nix configs in a non-linux environment is leveraging a Docker container. The general command for this approach is:
+While there are numerous ways of building Nix configurations, one way to build nix configs in a non-linux environment is
+leveraging a Docker container. The general command for this approach is:
+
 ```
 docker run --rm -it -v $(git rev-parse --show-toplevel):/build -w /build <nixDockerImage>@sha256<imageSHA256> /bin/sh
 ```
 
 Command notes:
-- Mounts a shared volume from the project's root with a new folder in the container, `/build`, allowing for the contents of the container to be shared with the host and vice verse
-- `nixDockerImage` is a Docker image that has the `nix` commands preinstalled. [This](https://hub.docker.com/r/nixos/nix) is one such image that can be used.
+- Mounts a shared volume from the project's root with a new folder in the container, `/build`, allowing for the contents
+  of the container to be shared with the host and vice verse
+- `nixDockerImage` is a Docker image that has the `nix` commands preinstalled. [This](https://hub.docker.com/r/nixos/nix)
+  is one such image that can be used.
 - `imageSHA256` is the Docker image's digest, which safely pins the image to a specific version.
 
+## Using the overlay
+
+All packages defined in `overlay.nix` can be used as a [nix overlay](https://nixos.org/manual/nixpkgs/stable/#chap-overlays)
+
+A sample `shell.nix`:
+
+```nix
+let
+  nix-garage = builtins.fetchGit {
+    url = "https://github.com/nebulaworks/nix-garage";
+    ref = "master";
+  };
+  garage-overlay = import (nix-garage.outPath + "/overlay.nix");
+  nixpkgs = import <nixpkgs> { overlays = [ garage-overlay ]; };
+in
+  with nixpkgs;
+  mkShell {
+    buildInputs = [
+        flasksample
+    ];
+  }
+```
+
+Then drop into the nix-shell and run the `flasksample` pkg:
+
+```bash
+$ nix-shell
+[nix-shell] $ export FLASK_APP=flasksample.app
+[nix-shell] $ flask run
+* Serving Flask app "flasksample.app"
+ * Environment: production
+   WARNING: This is a development server. Do not use it in a production deployment.
+   Use a production WSGI server instead.
+ * Debug mode: off
+ * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+```
 ### Contributing
 
 Please fork this repository and open a PR to contribute to this repository

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,8 @@
-{ pkgs ? import <nixpkgs> {} }:
-
-rec {
-  flasksample = pkgs.callPackage ./pkgs/flasksample {};
+{ nixpkgs ? import <nixpkgs> {} }:
+let
+  pkgs = import nixpkgs.path { overlays = [ (import ./overlay.nix) ]; };
+in
+{
+  pkgs = pkgs;
+  imgs = import ./imgs { inherit pkgs; };
 }

--- a/imgs/awsutils/default.nix
+++ b/imgs/awsutils/default.nix
@@ -1,7 +1,6 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem, pkgs }:
 let
   nwi = import ../../nwi.nix;
-  pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
   lib = pkgs.lib;
   contents = with pkgs; [ cacert coreutils bash jq curl awscli ];
 in

--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -1,0 +1,19 @@
+{ pkgs }:
+
+rec {
+  awsutils = pkgs.callPackage ./awsutils {
+    pkgs = import ../pin { snapshot = "nixos-20-03_0"; };
+  };
+
+  helmsman-aws = pkgs.callPackage ./helmsman-aws {
+    pkgs = import ../pin { snapshot = "nixpkgs-unstable_0"; };
+  };
+
+  magic-wormhole-mailbox = pkgs.callPackage ./magic-wormhole-mailbox {
+    pkgs = import ../pin { snapshot = "nixos-20-03_0"; };
+  };
+
+  pki-validator = pkgs.callPackage ./pki-validator {
+    pkgs = import ../pin { snapshot = "nixos-20-03_0"; };
+  };
+}

--- a/imgs/helmsman-aws/default.nix
+++ b/imgs/helmsman-aws/default.nix
@@ -1,7 +1,6 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem, pkgs }:
 let
   nwi = import ../../nwi.nix;
-  pkgs = import ../../pin { snapshot = "nixpkgs-unstable_0"; };
   callPackage = pkgs.lib.callPackageWith (pkgs // self);
 
   self = {

--- a/imgs/magic-wormhole-mailbox/default.nix
+++ b/imgs/magic-wormhole-mailbox/default.nix
@@ -1,7 +1,6 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem, pkgs }:
 let
   nwi = import ../../nwi.nix;
-  pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
   lib = pkgs.lib;
   importedPythonPkgs = with pkgs; python37.withPackages (pythonPkgs: with pythonPkgs; [ magic-wormhole-mailbox-server ]);
   contents = with pkgs; [ bash coreutils procps importedPythonPkgs ];

--- a/imgs/pki-validator/default.nix
+++ b/imgs/pki-validator/default.nix
@@ -1,7 +1,6 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem, pkgs }:
 let
   nwi = import ../../nwi.nix;
-  pkgs = import ../../pin { snapshot = "nixos-20-03_0"; };
   lib = pkgs.lib;
   contents = with pkgs; [ openssl coreutils bash gnumake gnugrep gawk ];
 in

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,4 @@
+self: super:
+{
+  flasksample = super.callPackage ./pkgs/flasksample {};
+}

--- a/publish-imgs
+++ b/publish-imgs
@@ -5,12 +5,7 @@ set -efo pipefail
 
 test -z $1 && (echo "pass in img" && exit 1)
 
-IMG_DIR="imgs/$1"
-
-# Make sure nix-build was run
-test -f ${IMG_DIR}/result || (echo "please build derivation" && exit 1)
-
-derivation=$(nix show-derivation $(nix-instantiate ${IMG_DIR}/default.nix))
+derivation=$(nix show-derivation $(nix-instantiate -A imgs.$1))
 registry="docker.io"
 image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
 org=$(echo $image_fullname | cut -d '/' -f 1)
@@ -19,7 +14,9 @@ calcout=$(echo $derivation | jq '.[] | .env.out')
 calcout=$(basename ${calcout} | cut -d '-' -f1)
 registry_endpoint="${registry}/${org}/${image_name}:${calcout}"
 
-# Check if this image is already in the registry
+# Check if this image is already in the registry and exit if so
 skopeo inspect docker://${registry_endpoint} && exit 0
+
+nix-build -A imgs.$1
 
 skopeo copy docker-archive:result docker://${registry_endpoint}


### PR DESCRIPTION
## Description
We should be leveraging an overlay and organizing our nix packages in a more clear manner. This should start us down that path

## Acceptance Criteria
* Images still build as expected
* Anyone can consume overlay.nix from this repo

## Testing

Using the new overlay. I had to leverage my branch but once we merge this into `master` we can leverage it via what I added in the README:

A sample `shell.nix`:

```nix
let
  nix-garage = builtins.fetchGit {
    url = "https://github.com/sarcasticadmin/nix-garage";
    ref = "sa/gl-issue-309";
  };
  garage-overlay = import (nix-garage.outPath + "/overlay.nix");
  nixpkgs = import <nixpkgs> { overlays = [ garage-overlay ]; };
in
  with nixpkgs;
  mkShell {
    buildInputs = [
        flasksample
    ];
  }
```

Then drop into the nix-shell and run the `flasksample` pkg:

```bash
$ nix-shell
[nix-shell] $ export FLASK_APP=flasksample.app
[nix-shell] $ flask run
* Serving Flask app "flasksample.app"
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
```

Then making sure that we can still build our images and reproducibility is still intacted:

```
$ for currImgPath in $(ls -d imgs/*/); do  ./publish-imgs $(basename $currImgPath); done
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
{                                                                                              
    "Name": "docker.io/nebulaworks/awsutils",                                                                                                                
    "Digest": "sha256:d22b87ad666430779b782c307b5afc52968995b860d7a77656a93a3f413ca14a",
    "RepoTags": [                                                                       
        "0afjz2x6jzlqbyp6hlsn7xx1j4v595xj",                                                                       
        "dz783iaashdby6phqf9pcydxsw1bbjq0",                    
        "ib0v6zkv2qqaidwda7sp64pa0jfc0vbs"                                            
    ],                                
    "Created": "1970-01-01T00:00:01Z",                                           
    "DockerVersion": "",
    "Labels": {                                                                               
        "com.nebulaworks.packages": "awscli:1.17.13,bash:4.4,coreutils:8.31,curl:7.68.0,jq:1.6,nss-cacert:3.49.2",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",                       
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },                      
    "Architecture": "amd64",                                                                   
    "Os": "linux",
    "Layers": [
         "sha256:2c8d5e5a38c0d8ae54c419a59a7df5d6106f66903df4dd26059e5a5d89a30f33"                                                                                                   
    ],
    "Env": [
        "PATH=/bin/",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
    ]
}
copying path '/nix/store/84qi3iba9m2xs2jm40kccvh0hyakkf2s-source' from 'https://cache.nixos.org'...
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
{
    "Name": "docker.io/nebulaworks/helmsman-aws",
    "Digest": "sha256:2cab619b7e43b30eb8384b9104b19499e4b0ac39c4347ae77ec5b3c65007c103",
    "RepoTags": [
        "0r4rskk3b5han0zzncj67sjhkm7lip1w",
        "2vil2iz4gz0lmcqsg92kxylhh4mds6jv",
        "72rs42ar65syxrgq6w0qyv98n97zkr6n",
        "7ar2sigpxxyll06yvgan428qn74k0vqm",
        "7hl8p275d7f3gcnam52s7hg1d307a2ik",
        "axk5j5bhv0sv9ys1xj4bmhc34kfw5jkn",
        "ibx9pd0yzvspf6gczmdmmhmam9sr25wr",
        "pbj9q2qyw511wfy18g8lz9jw2mpc5qvw",
        "sb47bkwd854ws9dc4gzsvnln06pidxjf",
        "xym39zji91ga5rbw6p8xbwy5dcbizbn3"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "awscli:1.17.13,bash:4.4,coreutils:8.31,helm-diff:3.1.1,helm:3.2.1,helmsman:3.3.0,jq:1.6,kubectl:1.18.1,nss-cacert:3.52",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:b59069cadaedf5c0ebef846dcc248bb64a9ee16b972fe6c8d6769efec56a1795"
    ],
    "Env": [
        "PATH=/bin/",
        "HELM_PLUGINS=/share/helm/plugins/"
    ]
}
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
{
    "Name": "docker.io/nebulaworks/magic-wormhole-mailbox",
    "Digest": "sha256:6bb9e8430553918346aa3e602727d5ef657171c347749b01f52bf77e57492c56",
    "RepoTags": [
        "msahb86b470r5636v8imzs8sghgzg38b"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "bash:4.4,coreutils:8.31,procps:3.3.16,python3:3.7.6-env",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:2dd20c82cb559ffbb4a4b185619d524dee48b3f3b34af40349bf98aca07874cc"
    ],
    "Env": [
        "PATH=/bin/"
    ]
}
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
{
    "Name": "docker.io/nebulaworks/pki-validator",
    "Digest": "sha256:9be4e1655ccb7b906f9c0109394ad6bb733634c3e4862c6866f8cf19d5829c71",
    "RepoTags": [
        "12x2y4s04wqd7vzblyknmb4i9wlrbyg7"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "bash:4.4,coreutils:8.31,gawk:5.0.1,gnugrep:3.4,gnumake:4.2.1,openssl:1.1.1d",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:e6ac3abb53a8af091b4c040681b8615355e84bdf1ac92a57c87312253ecce851"
    ],
    "Env": [
        "PATH=/bin/",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
    ]
}
```
No new images 😄 ! And we cant completely validate CI since its reading its configuration from `.github` dir off `master` which makes some assumes that Ive corrected for these changes.