### PR TITLE
[READY] - sshcb init 0.2.1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Description of PR
+
+## Previous Behavior
+Remove this section if not relevant
+
+## New Behavior
+Remove this section if not relevant
+
+## Tests
+- How was this PR tested?

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,5 @@
 self: super:
 {
   flasksample = super.callPackage ./pkgs/flasksample {};
+  sshcb = super.callPackage ./pkgs/sshcb {};
 }

--- a/pkgs/sshcb/default.nix
+++ b/pkgs/sshcb/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "sshcb";
+  version = "0.2.1";
+  owner = "sarcasticadmin";
+  rev = "v${version}";
+
+  src = fetchFromGitHub {
+    inherit owner rev;
+    repo = pname;
+    sha256 = "0i34j2llnxikam0p9919f9k1k35yjjvcd4q1zc2ws7k5f854jw2f";
+  };
+
+  modSha256 = "1vjlhi08j4ihxjw1mq642fqqzlbzvqmg9c7p2ng808nrzmqj53xi";
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X github.com/${owner}/${pname}/cmd.Version=${rev}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Generate an ssh_config from cloud resources";
+    homepage = "https://github.com/sarcasticadmin/sshcb";
+    maintainers = with maintainers; [ sarcasticadmin ];
+    license = licenses.bsd2;
+  };
+}


### PR DESCRIPTION
## Description

Adding `sshcb` to our overlay as its something that we leverage when needing to build an ssh_config using EC2metadata

## Test

`sshcb` builds:

```
$ nix-build -A pkgs.sshcb
/nix/store/inikz4fkpxmyaygzwcjw61wvaf8dygrp-sshcb-0.2.1
```

`sshcb` works as expected:
```
$ nix-shell -p "with import ./default.nix {}; pkgs.sshcb"

[nix-shell:~/nix-garage]$ sshcb version
v0.2.1
```