### PR TITLE
[READY] add git-lfs, tar and gzip to awsutils img

### DIFF
--- a/imgs/awsutils/default.nix
+++ b/imgs/awsutils/default.nix
@@ -2,7 +2,7 @@
 let
   nwi = import ../../nwi.nix;
   lib = pkgs.lib;
-  contents = with pkgs; [ cacert coreutils bash jq curl awscli git ];
+  contents = with pkgs; [ cacert coreutils bash jq curl awscli git git-lfs gnutar gzip ];
 in
 pkgs.dockerTools.buildImage {
   inherit contents;


### PR DESCRIPTION
## Description of PR
awsutils needs git-lfs, tar and gzip installed in order to properly backup lfs repos.

## Tests
awsutils builds:
```
nix-build -A imgs.utils
/nix/store/c3skllz0pvp6a78nf3c4fck7xcg1yxq5-docker-image-awsutils.tar.gz
```

awsutils works as expected:
```
docker run -it nebulaworks/awsutils:latest /bin/sh
sh-4.4# tar --version
tar (GNU tar) 1.32
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by John Gilmore and Jay Fenlason.
sh-4.4# gzip --version
gzip 1.10
Copyright (C) 2018 Free Software Foundation, Inc.
Copyright (C) 1993 Jean-loup Gailly.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <https://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.

Written by Jean-loup Gailly.
sh-4.4# git lfs version
git-lfs/2.8.0 (GitHub; linux amd64; go 1.12.17)
```