### PR TITLE
[READY] do/issue-419: fix sshcb nix build

### DIFF
--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -22,7 +22,7 @@ jobs:
         # Utilizes the commit from the open PR
         # Using SHA v2
       - name: Pulls Repository
-        uses: actions/checkout@28c7f3d2
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -76,7 +76,7 @@ jobs:
       # Utilizes the commit from the open PR, which was gotten from the previous step
       # Using SHA v2
       - name: Pulls Repository Code
-        uses: actions/checkout@28c7f3d2
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
         with:
           ref: ${{ needs.verify.outputs.sha }}
 
@@ -133,7 +133,7 @@ jobs:
       # Creates PR comment telling commentor that there was an issue with the commit SHA for the PR 
       - name: Create Faulure PR Comment for Invalid Commit SHA
         if: needs.verify.outputs.status == 'invalidsha'
-        uses: jungwinter/comment@5acbb   # SHA ref v1.0.2
+        uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed   # SHA ref v1.0.2
         with:
           type: create
           body: |
@@ -146,7 +146,7 @@ jobs:
       # Creates a PR comment telling commenter to ask an approved user to pubish images
       - name: Create Failure PR Comment for Verifying
         if: needs.verify.outputs.status == 'failure'
-        uses: jungwinter/comment@5acbb   # SHA ref v1.0.2
+        uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed   # SHA ref v1.0.2
         with:
           type: create
           body: |
@@ -160,7 +160,7 @@ jobs:
       # Creates a PR comment showing commenter images that were built as well as a link to the page where they currently exist
       - name: Create Success PR Comment
         if: needs.verify.outputs.status == 'success' && needs.publish.result == 'success'
-        uses: jungwinter/comment@5acbb  # SHA ref v1.0.2
+        uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed  # SHA ref v1.0.2
         with:
           type: create
           body: |

--- a/pkgs/sshcb/default.nix
+++ b/pkgs/sshcb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "sshcb";
@@ -12,7 +12,7 @@ buildGoModule rec {
     sha256 = "0i34j2llnxikam0p9919f9k1k35yjjvcd4q1zc2ws7k5f854jw2f";
   };
 
-  modSha256 = "1vjlhi08j4ihxjw1mq642fqqzlbzvqmg9c7p2ng808nrzmqj53xi";
+  vendorSha256 = "1zgf7fczm0nx7x6lqjjxy0gkd53amszjjyc9ldy4rzf7y8n15ry1";
 
   buildFlagsArray = [
     "-ldflags="
@@ -21,7 +21,7 @@ buildGoModule rec {
     "-X github.com/${owner}/${pname}/cmd.Version=${rev}"
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Generate an ssh_config from cloud resources";
     homepage = "https://github.com/sarcasticadmin/sshcb";
     maintainers = with maintainers; [ sarcasticadmin ];


### PR DESCRIPTION
## Description of PR
Running `nix-build` for `sshcb` was broken in the current version of Nix. To fix this:
* Standardized the imports to `nixpkgs`.
* Fix `modSha256` to `vendorSha256` with the current checksum.
* `stdenv.lib` -> `lib`

## Previous Behavior
It was borked.

## New Behavior
It's not borked anymore.

## Tests
Tested in a Vagrant box - 20.04 with the current version of Nix. Successfully ran `nix-build` and verified the built executable worked.