### PR TITLE
[READY] do/issue-421: add aws-key-rotator nix build

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -3,4 +3,5 @@ self: super:
   flasksample = super.callPackage ./pkgs/flasksample {};
   sshcb = super.callPackage ./pkgs/sshcb {};
   codefresh = super.callPackage ./pkgs/codefresh {};
+  aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator {};
 }

--- a/pkgs/aws-key-rotator/default.nix
+++ b/pkgs/aws-key-rotator/default.nix
@@ -1,0 +1,23 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "aws-key-rotator";
+  version = "0.1.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "davidjoliver86";
+    rev = "bfbbf6b439764c1a0e7a29be25d537b75dcdcee6";
+    repo = "aws-key-rotator";
+    sha256 = "1k14gn5vn852krhnshq6klf31mly4yhff3yvfq9ah9gp8i50ab81";
+  };
+
+  nativeBuildInputs = [ python3Packages.poetry ];
+  propagatedBuildInputs = [ python3Packages.boto3 python3Packages.coloredlogs ];
+
+  meta = with lib; {
+    description = "Automated AWS IAM user key rotation";
+    license = licenses.bsd3;
+    maintainers = "NWI";
+  };
+}


### PR DESCRIPTION
## Description of PR
Make a `nix` build for `aws-key-rotator`.

## Tests
Tested in my VM. Successfully built with `nix build -A pkgs.aws-key-rotator` and successfully ran it.