### PR TITLE
[REVIEW] do/issue-345: add install cachix workflow

### DIFF
--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -8,7 +8,7 @@
 # 5. Once we logged in, we then execute the script "publish-imgs", which will publish the image passed into it.
 # 6. If successful, the job will create a new PR comment saying all of the images that were published as well as a link to the page with all of the images
 
-name: Publish Docker Images
+name: Publish Docker images
 
 on:
   # This job will be fired off when a comment has been made in an issue (which also impliitly includes PRs)
@@ -17,11 +17,11 @@ on:
 
 jobs:
   verify:
-    name: Verify Commenter    
+    name: Verify commenter
     runs-on: ubuntu-18.04
 
     # Checks if the comment contains the word 'publish as well as if the comment was made in a PR
-    if: > 
+    if: >
       startsWith(github.event.comment.body, 'publish')
       && startsWith(github.event.issue.pull_request.url, 'https://')
 
@@ -29,10 +29,10 @@ jobs:
     outputs:
       status: ${{ steps.verify.outputs.status }}
       sha: ${{ steps.verify.outputs.sha }}
-    
+
     steps:
       # Verifies if commenter is approver, in which it will extract PR's head commit sha
-      - name: Verify Commenter is Approver
+      - name: Verify commenter is approver
         id: verify
         run: |
           set -x
@@ -58,7 +58,7 @@ jobs:
         continue-on-error: true
 
   publish:
-    name: Prepare and Publish Images
+    name: Prepare and publish images
     runs-on: ubuntu-18.04
     needs: verify
 
@@ -70,18 +70,33 @@ jobs:
     # Utilizing nixos/nix docker image v2.3
     container:
       image: nixos/nix@sha256:af330838e838cedea2355e7ca267280fc9dd68615888f4e20972ec51beb101d8
-    
+
     steps:
       # Checks out repository to docker container
       # Utilizes the commit from the open PR, which was gotten from the previous step
       # Using SHA v2
-      - name: Pulls Repository Code
+      - name: Pulls repository code
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
         with:
           ref: ${{ needs.verify.outputs.sha }}
 
+      - name: Install bash
+        run: |
+          mkdir /github/home/.nix-defexpr
+          ln -s /nix/var/nix/profiles/default /github/home/.nix-profile
+          ln -s /nix/var/nix/profiles/per-user/root/channels /github/home/.nix-defexpr/channels
+          nix-env -iA nixpkgs.bash
+        shell: sh {0}
+        continue-on-error: false
+
+      - name: Install Cachix
+        uses: cachix/cachix-action@73e75d1a0cd4330597a571e8f9dedb41faa2fc4e  # v10
+        with:
+          name: nebulaworks
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
       # Attempt to authenticatie to Docker hub and publish all images
-      - name: Authenticate and Execute Publish Script
+      - name: Authenticate and execute publish script
         id: publish
         run: |
           cat << EOF > $GITHUB_WORKSPACE/data.json
@@ -99,15 +114,15 @@ jobs:
             }
           }
           EOF
-          
+
           export DOCKER_HUB_TOKEN=$(nix-shell --run "curl -s -H 'Content-Type: application/json' -X POST \
           -d @$GITHUB_WORKSPACE/data.json --url https://hub.docker.com/v2/users/login/ | jq -r .token")
           set -x
           export REGISTRY_AUTH_FILE=$GITHUB_WORKSPACE/auth.json
 
           cd $GITHUB_WORKSPACE
-          allImgs=""          
-          for currImgPath in $(ls -d $GITHUB_WORKSPACE/imgs/*/); do 
+          allImgs=""
+          for currImgPath in $(ls -d $GITHUB_WORKSPACE/imgs/*/); do
             currImgName=$(basename $currImgPath)
             if [ -z $allImgs ]; then
               allImgs="$currImgName"
@@ -125,46 +140,46 @@ jobs:
         continue-on-error: false
 
   post:
-    name: Generate PR Comments
+    name: Generate PR comments
     runs-on: ubuntu-18.04
     needs: [verify, publish]
 
     steps:
-      # Creates PR comment telling commentor that there was an issue with the commit SHA for the PR 
-      - name: Create Faulure PR Comment for Invalid Commit SHA
+      # Creates PR comment telling commentor that there was an issue with the commit SHA for the PR
+      - name: Create failure PR comment for invalid commit SHA
         if: needs.verify.outputs.status == 'invalidsha'
         uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed   # SHA ref v1.0.2
         with:
           type: create
           body: |
-            Hm, there was an issue with the commit SHA used to obtain the repository. 
+            Hm, there was an issue with the commit SHA used to obtain the repository.
             Please verify the commit SHA used: `${{ needs.verify.outputs.sha }}`
           token: ${{ secrets.NWIAUTO_PAT }}
           issue_number: ${{ github.event.issue.number }}
         continue-on-error: false
 
       # Creates a PR comment telling commenter to ask an approved user to pubish images
-      - name: Create Failure PR Comment for Verifying
+      - name: Create failure PR comment for verifying
         if: needs.verify.outputs.status == 'failure'
         uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed   # SHA ref v1.0.2
         with:
           type: create
           body: |
             User `${{ github.event.comment.user.login }}` is not authorized to publish images from this repository.
-            
+
             Comment with a mention to `nebulaworks/approvers` to notify the approvers team to publishing the new Docker images.
           token: ${{ secrets.NWIAUTO_PAT }}
           issue_number: ${{ github.event.issue.number }}
         continue-on-error: false
 
       # Creates a PR comment showing commenter images that were built as well as a link to the page where they currently exist
-      - name: Create Success PR Comment
+      - name: Create success PR comment
         if: needs.verify.outputs.status == 'success' && needs.publish.result == 'success'
         uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed  # SHA ref v1.0.2
         with:
           type: create
           body: |
-            The following docker images: 
+            The following docker images:
             ${{ needs.publish.outputs.allImgs }}
             have been published on [Docker Hub](https://hub.docker.com/u/nebulaworks).
           token: ${{ secrets.NWIAUTO_PAT }}


### PR DESCRIPTION
## Description of PR
Need to install Cachix so that our Nix-built Docker images can reference a binary cache.

## Previous Behavior
No Cachix.

## New Behavior
Yay Cachix.

## Tests
Tested within my forked repo. Verified that installing Cachix succeeded. I don't have access to the other secrets in `Nebulaworks/nix-garage` so I can't fully vet the whole workflow here. For `NWIAUTO_PAT` in this repo, I just made my own PAT and used that.