### PR TITLE
[READY] do/issue-436: add terraform-config-inspect nix build

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -4,4 +4,5 @@ self: super:
   sshcb = super.callPackage ./pkgs/sshcb {};
   codefresh = super.callPackage ./pkgs/codefresh {};
   aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator {};
+  terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect {};
 }

--- a/pkgs/terraform-config-inspect/default.nix
+++ b/pkgs/terraform-config-inspect/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "terraform-config-inspect-unstable";
+  version = "2021-04-27";
+  owner = "hashicorp";
+  rev = "9a80970d6b348d0c23719ed60bccb83d4bfc2ccd"; # only master branch and no tags; latest commit sha as of 2021-04-27
+
+  src = fetchFromGitHub {
+    inherit owner rev;
+    repo = "terraform-config-inspect";
+    sha256 = "1x9ifpk28r9hldpvig92zsvrl5hxzc0gj75q5xr20zb3jb22q11n";
+  };
+
+  vendorSha256 = "14r0q13hi8x7h6kkb26i8v1ialwk86ykgmn53i7874w1kvmzx2hg";
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Terraform config inspect Go module and CLI tool";
+    homepage = "https://github.com/hashicorp/terraform-config-inspect";
+    maintainers = "NWI";
+    license = licenses.bsd2;
+  };
+}


### PR DESCRIPTION
## Description of PR
Creating a new nix build for `terraform-config-inspect`. Also tested building with Cachx and pushed the binaries up.

The main caveat was that I had to fork the original repo in order to add a tag and create a version, as the original repo only has a `master` branch and no tags at all.

Fork: https://github.com/davido-nw/terraform-config-inspect
Original: https://github.com/hashicorp/terraform-config-inspect

The version I created was basically just today's timestamp.

## Tests
- Built locally.