### PR TITLE
[READY] - Updating reference for flasksample

### DIFF
--- a/pkgs/flasksample/default.nix
+++ b/pkgs/flasksample/default.nix
@@ -1,16 +1,23 @@
-{ lib, python3Packages, fetchFromGitHub }:
-
-python3Packages.buildPythonPackage rec {
-  pname = "flasksample";
-  version = "0.0.1";
-
-  # This is on my own fork but will bring this into NWI org in a followup
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+let
   src = fetchFromGitHub {
-    owner = "sarcasticadmin";
-    rev = "1edd490a7d36727d2f9b0846fd3536f7b1baba45";
-    repo = "flaskapp";
-    sha256 = "1dmmg79lp0dr2sy9drrpj7k1bbs53awwqqckdyfjxvl0fj7pfmkb";
+    owner = "nebulaworks";
+    rev = "3f9676f6775054456f6082807d5ece05e12420ee";
+    repo = "orion";
+    sha256 = "074kyr15cqcd79n0dbv7ycra4ky0fkm1iw5cprznp8pjwwqmgnlm";
   };
+in
+python3Packages.buildPythonPackage rec {
+  # drv still needs src even though application is in subdir
+  inherit src;
+  pname = "flasksample";
+  version = "0.1.0";
+
+  # Need to look at the subdirectory since theres multiple apps here
+  sourceRoot = "${src.name}/apps/flasksample";
 
   propagatedBuildInputs = [ python3Packages.flask ];
 


### PR DESCRIPTION
## Description of PR

Requires: https://github.com/Nebulaworks/orion/pull/1

No longer need to reference my random fork for this code, but instead it can now be found as part of `orion`

## Previous Behavior
- Leveraged @sarcasticadmin fork for flasksample project
- Needed to `export FLASK_APP=flasksample.app` env variable before running `flask run`

## New Behavior
- Leverage sample app in `orion`
- Created entry_point to be able to run application by name: `flasksample`

## Tests

building pkgs works:

```
$ nix-build -A pkgs.flasksample
these derivations will be built:
  /nix/store/dalnpxnl8gvgbnqman554yark627vsca-python3.8-flasksample-0.1.0.drv
building '/nix/store/dalnpxnl8gvgbnqman554yark627vsca-python3.8-flasksample-0.1.0.drv'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
unpacking sources
unpacking source archive /nix/store/5lvz1q17fc1qssbnhbjlwl4yvkick8k1-source
source root is source/apps/flasksample
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/apps/flasksample/setup.py
patching sources
configuring
no configure script, doing nothing
building
Executing setuptoolsBuildPhase
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/flasksample
copying flasksample/test_utils.py -> build/lib/flasksample
copying flasksample/__init__.py -> build/lib/flasksample
copying flasksample/utils.py -> build/lib/flasksample
copying flasksample/app.py -> build/lib/flasksample
copying flasksample/test_hit.py -> build/lib/flasksample
copying flasksample/hit.py -> build/lib/flasksample
installing to build/bdist.macosx-10.6-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.6-x86_64
creating build/bdist.macosx-10.6-x86_64/wheel
creating build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/test_utils.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/__init__.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/utils.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/app.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/test_hit.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
copying build/lib/flasksample/hit.py -> build/bdist.macosx-10.6-x86_64/wheel/flasksample
running install_egg_info
running egg_info
creating flasksample.egg-info
writing flasksample.egg-info/PKG-INFO
writing dependency_links to flasksample.egg-info/dependency_links.txt
writing entry points to flasksample.egg-info/entry_points.txt
writing requirements to flasksample.egg-info/requires.txt
writing top-level names to flasksample.egg-info/top_level.txt
writing manifest file 'flasksample.egg-info/SOURCES.txt'
reading manifest file 'flasksample.egg-info/SOURCES.txt'
writing manifest file 'flasksample.egg-info/SOURCES.txt'
Copying flasksample.egg-info to build/bdist.macosx-10.6-x86_64/wheel/flasksample-0.1.0-py3.8.egg-info
running install_scripts
creating build/bdist.macosx-10.6-x86_64/wheel/flasksample-0.1.0.dist-info/WHEEL
creating 'dist/flasksample-0.1.0-py3-none-any.whl' and adding 'build/bdist.macosx-10.6-x86_64/wheel' to it
adding 'flasksample/__init__.py'
adding 'flasksample/app.py'
adding 'flasksample/hit.py'
adding 'flasksample/test_hit.py'
adding 'flasksample/test_utils.py'
adding 'flasksample/utils.py'
adding 'flasksample-0.1.0.dist-info/METADATA'
adding 'flasksample-0.1.0.dist-info/WHEEL'
adding 'flasksample-0.1.0.dist-info/entry_points.txt'
adding 'flasksample-0.1.0.dist-info/top_level.txt'
adding 'flasksample-0.1.0.dist-info/RECORD'
removing build/bdist.macosx-10.6-x86_64/wheel
Finished executing setuptoolsBuildPhase
installing
Executing pipInstallPhase
/private/tmp/nix-build-python3.8-flasksample-0.1.0.drv-0/source/apps/flasksample/dist /private/tmp/nix-build-python3.8-flasksample-0.1.0.drv-0/source/apps/flasksample
Processing ./flasksample-0.1.0-py3-none-any.whl
Requirement already satisfied: flask in /nix/store/hjrqwdj3wqivnwspji17qjgrghijafc8-python3.8-Flask-1.1.2/lib/python3.8/site-packages (from flasksample==0.1.0) (1.1.2)
Requirement already satisfied: Werkzeug>=0.15 in /nix/store/axhlj8zfci3402mzqs6snlsfxcfws46n-python3.8-Werkzeug-1.0.1/lib/python3.8/site-packages (from flask->flasksample==0.1.0) (1.0.1)
Requirement already satisfied: itsdangerous>=0.24 in /nix/store/d4aw4dsdfxjzac209fa41szm5dawg0fz-python3.8-itsdangerous-1.1.0/lib/python3.8/site-packages (from flask->flasksample==0.1.0) (1.1.0)
Requirement already satisfied: Jinja2>=2.10.1 in /nix/store/n43gh070bpm4rprdndbpf3cx3dadv62f-python3.8-Jinja2-2.11.3/lib/python3.8/site-packages (from flask->flasksample==0.1.0) (2.11.3)
Requirement already satisfied: click>=5.1 in /nix/store/011fbwmq4zmdyz30z6mm35902jj5sj7m-python3.8-click-7.1.2/lib/python3.8/site-packages (from flask->flasksample==0.1.0) (7.1.2)
Requirement already satisfied: MarkupSafe>=0.23 in /nix/store/xk1p684c89cjy98gcqlgn8bw4lp33d6l-python3.8-MarkupSafe-1.1.1/lib/python3.8/site-packages (from Jinja2>=2.10.1->flask->flasksample==0.1.0) (1.1.1)
Installing collected packages: flasksample
Successfully installed flasksample-0.1.0
/private/tmp/nix-build-python3.8-flasksample-0.1.0.drv-0/source/apps/flasksample
Finished executing pipInstallPhase
post-installation fixup
strip is /nix/store/s31f50385mj95q0ws54g2m3msxshvmkd-cctools-binutils-darwin-949.0.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/n8kg1jh9xxflyz7qwj9f0x4cvshpjhk3-python3.8-flasksample-0.1.0/lib  /nix/store/n8kg1jh9xxflyz7qwj9f0x4cvshpjhk3-python3.8-flasksample-0.1.0/bin
patching script interpreter paths in /nix/store/n8kg1jh9xxflyz7qwj9f0x4cvshpjhk3-python3.8-flasksample-0.1.0
Rewriting #!/nix/store/rakqkwxql1hsa16dphdfkdky8i9cib5v-python3-3.8.8/bin/python3.8 to #!/nix/store/rakqkwxql1hsa16dphdfkdky8i9cib5v-python3-3.8.8
wrapping `/nix/store/n8kg1jh9xxflyz7qwj9f0x4cvshpjhk3-python3.8-flasksample-0.1.0/bin/flasksample'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
running install tests
no Makefile or custom installCheckPhase, doing nothing
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
setuptoolsCheckPhase
Executing setuptoolsCheckPhase
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing flasksample.egg-info/PKG-INFO
writing dependency_links to flasksample.egg-info/dependency_links.txt
writing entry points to flasksample.egg-info/entry_points.txt
writing requirements to flasksample.egg-info/requires.txt
writing top-level names to flasksample.egg-info/top_level.txt
reading manifest file 'flasksample.egg-info/SOURCES.txt'
writing manifest file 'flasksample.egg-info/SOURCES.txt'
running build_ext
test_gethostname (flasksample.test_utils.TestUtils) ... ok
test_getlocaladdress (flasksample.test_utils.TestUtils) ... ok
test_getServerHitCount (flasksample.test_hit.TestHit) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.010s

OK
Finished executing setuptoolsCheckPhase
/nix/store/n8kg1jh9xxflyz7qwj9f0x4cvshpjhk3-python3.8-flasksample-0.1.0
```

```
$ nix-shell -p "with import ./default.nix {}; pkgs.flasksample"

[nix-shell:~/workspace/nix-garage]$ flasksample
 * Serving Flask app "flasksample.app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 ```
 
 webserver responses as expected:
 ```
 $ curl http://0.0.0.0:5000/
<html><head><title>Docker + Flask Demo</title></head><body><table><tr><td> Start Time </td> <td>2021-Jun-24 17:00:18</td> </tr><tr><td> Hostname </td> <td>setups-MBP.local</td> </tr><tr><td> Local Address </td> <td>192.x.x.x</td> </tr><tr><td> Remote Address </td> <td>127.0.0.1</td> </tr><tr><td> Server Hit </td> <td>1</td> </tr></table>
```