### PR TITLE
[READY] - Adding flasksample container to our list of imgs

### DIFF
--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -5,6 +5,8 @@ rec {
     pkgs = import ../pin { snapshot = "nixos-20-03_0"; };
   };
 
+  flasksample = pkgs.callPackage ./flasksample {};
+
   helmsman-aws = pkgs.callPackage ./helmsman-aws {
     pkgs = import ../pin { snapshot = "nixpkgs-unstable_0"; };
   };

--- a/imgs/flasksample/README.md
+++ b/imgs/flasksample/README.md
@@ -1,0 +1,8 @@
+# flasksample
+
+A lightweight web server that runs contains a counter for each request served.
+
+Application code can be found at: https://github.com/Nebulaworks/orion
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/flasksample/default.nix
+++ b/imgs/flasksample/default.nix
@@ -1,0 +1,26 @@
+{ system ? builtins.currentSystem, pkgs }:
+let
+  nwi = import ../../nwi.nix;
+  lib = pkgs.lib;
+  contents = with pkgs; [ coreutils bash flasksample ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/flasksample";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+  '';
+  config = {
+    Cmd = [ "/bin/flasksample" ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+    WorkingDir = "/";
+  };
+}

--- a/pkgs/flasksample/default.nix
+++ b/pkgs/flasksample/default.nix
@@ -5,9 +5,9 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "3f9676f6775054456f6082807d5ece05e12420ee";
+    rev = "981295e99309d28f5d7461fa0f6b09466eefe034";
     repo = "orion";
-    sha256 = "074kyr15cqcd79n0dbv7ycra4ky0fkm1iw5cprznp8pjwwqmgnlm";
+    sha256 = "12nbb2a50fa1v3sffq7f584xcwjl1wfhjs659cxnkyvimfx4iwvf";
   };
 in
 python3Packages.buildPythonPackage rec {


### PR DESCRIPTION
## Description of PR

Requires: #31 

Now that we have `flasksample` in orion, lets make a container for running it.

## Previous Behavior
- No container for `flasksample` existed outside of the one for the originator

## New Behavior
- We can now build our fork of `flasksample` and put it into a container
- Publish flasksample to dockerhub

## Tests
CI built image successfully: https://github.com/Nebulaworks/nix-garage/runs/3033686285?check_suite_focus=true

Pulling it down locally and running it:
```
$ docker run -it -p 5000:5000 nebulaworks/flasksample:kxhq2jcijnkp8qhnlhy47023jcd0rj52
 * Serving Flask app "flasksample.app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
172.17.0.1 - - [10/Jul/2021 00:24:04] "GET / HTTP/1.1" 200 -
172.17.0.1 - - [10/Jul/2021 00:24:06] "GET / HTTP/1.1" 200 -
172.17.0.1 - - [10/Jul/2021 00:24:12] "GET / HTTP/1.1" 200 -
```

Able to `curl` the endpoint as expected:

```
$ curl http://0.0.0.0:5000/
<html><head><title>Docker + Flask Demo</title></head><body><table><tr><td> Start Time </td> <td>2021-Jul-10 00:23:56</td> </tr><tr><td> Hostname </td> <td>be091c3009ae</td> </tr><tr><td> Local Address </td> <td>172.17.0.3</td> </tr><tr><td> Remote Address </td> <td>172.17.0.1</td> </tr><tr><td> Server Hit </td> <td>3</td> </tr></table></body>
```
