### PR TITLE
[READY] - Bump nix ci container to v2.3.12

### DIFF
--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -13,9 +13,9 @@ jobs:
     name: Run nixpkgs-fmt
     runs-on: ubuntu-18.04
 
-    # nixos/nix docker image v2.3 SHA
+    # Utilizing nixos/nix docker image v2.3.12
     container:
-      image: nixos/nix@sha256:af330838e838cedea2355e7ca267280fc9dd68615888f4e20972ec51beb101d8
+      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
 
     steps:
         # Checks out repository to docker container

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -67,9 +67,9 @@ jobs:
     outputs:
       allImgs: ${{ steps.publish.outputs.allImgs }}
 
-    # Utilizing nixos/nix docker image v2.3
+    # Utilizing nixos/nix docker image v2.3.12
     container:
-      image: nixos/nix@sha256:af330838e838cedea2355e7ca267280fc9dd68615888f4e20972ec51beb101d8
+      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
 
     steps:
       # Checks out repository to docker container


### PR DESCRIPTION
## Description of PR

Were getting an error: 

```
 for currImgPath in $(ls -d $GITHUB_WORKSPACE/imgs/*/)
++ basename /__w/nix-garage/nix-garage/imgs/flasksample/
+ currImgName=flasksample
+ '[' -z awsutils ']'
+ allImgs='awsutils, flasksample'
+ set +x
Docker Hub repo flasksample does not exist in nebulaworks, creating now...
{"user": "nebulaworks", "name": "flasksample", "namespace": "nebulaworks", "repository_type": null, "status": 0, "description": "", "is_private": false, "is_automated": false, "can_edit": true, "star_count": 0, "pull_count": 0, "last_updated": null, "is_migrated": false, "collaborator_count": 0, "affiliation": "owner", "hub_user": "nwiauto", "full_description": ""}
User is actually organization, attempting to add engineering group with read/write permissions in repo flasksample...
{"group_name": "engineering", "permission": "write", "group_id": 38264}
Adding ./imgs/flasksample/README.md to repo...
Results: 200
error: attribute 'getName' missing, at /__w/nix-garage/nix-garage/imgs/flasksample/default.nix:20:124
(use '--show-trace' to show detailed location information)
basename: missing operand
Try 'basename --help' for more information.
Error: Process completed with exit code 1.
```

Seems like the default version of nixpkgs in this container is too old and doesnt contain `getName` attribute by default.

See CI run: https://github.com/Nebulaworks/nix-garage/actions/runs/983612448

## Previous Behavior
- nix CI Container is old

## New Behavior
- nix CI container is v2.3.12

## Tests
- Linting works in this PR check for the image
- Testing building .yml in separate repo with a subset of `job` declarations and it works well:

```
wrapping `/nix/store/fzx5r8j8r5rdjgr212rb0fixrhfkzakc-python3.8-flasksample-0.1.0/bin/flasksample'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
running install tests
no Makefile or custom installCheckPhase, doing nothing
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
setuptoolsCheckPhase
Executing setuptoolsCheckPhase
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing flasksample.egg-info/PKG-INFO
writing dependency_links to flasksample.egg-info/dependency_links.txt
writing entry points to flasksample.egg-info/entry_points.txt
writing requirements to flasksample.egg-info/requires.txt
writing top-level names to flasksample.egg-info/top_level.txt
reading manifest file 'flasksample.egg-info/SOURCES.txt'
writing manifest file 'flasksample.egg-info/SOURCES.txt'
running build_ext
test_getServerHitCount (flasksample.test_hit.TestHit) ... ok
test_gethostname (flasksample.test_utils.TestUtils) ... ok
test_getlocaladdress (flasksample.test_utils.TestUtils) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.006s

OK
Finished executing setuptoolsCheckPhase
building '/nix/store/vmdpkr5vinq6wfc6myzf1ww7hs058njm-docker-layer-flasksample.drv'...
Adding contents...
Adding /nix/store/0vkw1m51q34dr64z5i87dy99an4hfmyg-coreutils-8.32
Adding /nix/store/a4yw1svqqk4d8lhwinn9xp847zz9gfma-bash-4.4-p23
Adding /nix/store/fzx5r8j8r5rdjgr212rb0fixrhfkzakc-python3.8-flasksample-0.1.0
Packing layer...
Finished building layer 'flasksample'
building '/nix/store/mkfrarqw75xcwhvrvm0h32h15kf806kj-runtime-deps.drv'...
building '/nix/store/4hvxd2fd0kzcb345qavvggjvakxxagi1-docker-image-flasksample.tar.gz.drv'...
Adding layer...
tar: Removing leading `/' from member names
Adding meta...
Cooking the image...
Finished.
/nix/store/rzk3f7a3w0ww8rlzi3401z3bz4mkmrn4-docker-image-flasksample.tar.gz
```