### PR TITLE
[READY] - Updating pins for toplevel nix-shell 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {} }:
+{ nixpkgs ? import <nixpkgs> { } }:
 let
   pkgs = import nixpkgs.path { overlays = [ (import ./overlay.nix) ]; };
 in

--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -5,7 +5,7 @@ rec {
     pkgs = import ../pin { snapshot = "nixos-20-03_0"; };
   };
 
-  flasksample = pkgs.callPackage ./flasksample {};
+  flasksample = pkgs.callPackage ./flasksample { };
 
   helmsman-aws = pkgs.callPackage ./helmsman-aws {
     pkgs = import ../pin { snapshot = "nixpkgs-unstable_0"; };

--- a/imgs/helmsman-aws/default.nix
+++ b/imgs/helmsman-aws/default.nix
@@ -4,7 +4,7 @@ let
   callPackage = pkgs.lib.callPackageWith (pkgs // self);
 
   self = {
-    helm-diff = callPackage ./pkgs/helm-diff {};
+    helm-diff = callPackage ./pkgs/helm-diff { };
   };
 
   lib = pkgs.lib;

--- a/imgs/magic-wormhole-mailbox/default.nix
+++ b/imgs/magic-wormhole-mailbox/default.nix
@@ -23,7 +23,7 @@ pkgs.dockerTools.buildImage {
       "PATH=/bin/"
     ];
     ExposedPorts = {
-      "4000/tcp" = {};
+      "4000/tcp" = { };
     };
     WorkingDir = "/var/lib/magic-wormhole-mailbox";
     EntryPoint = [ "twist" "wormhole-mailbox" "--usage-db=usage.sqlite" "--port=tcp:4000" ];

--- a/isos/yubikey/default.nix
+++ b/isos/yubikey/default.nix
@@ -67,7 +67,7 @@ with pkgs; {
   # Air-gapped system
   boot.initrd.network.enable = false;
   networking.dhcpcd.enable = false;
-  networking.dhcpcd.allowInterfaces = [];
+  networking.dhcpcd.allowInterfaces = [ ];
   networking.firewall.enable = true;
   networking.useDHCP = false;
   networking.useNetworkd = false;
@@ -85,19 +85,19 @@ with pkgs; {
   # Sets up the shell to have an environment variable that creates the directory for all generated keys
   # Also utilizes a preconfigured gpg config and configures a gpg-agent config.
   environment.interactiveShellInit = ''
-    export GNUPGHOME=/run/user/$(id -u)/gnupghome
-    if [ ! -d $GNUPGHOME ]; then
-    mkdir $GNUPGHOME
-    fi
-    sudo cp ${pkgs.fetchurl {
-    url = "https://raw.githubusercontent.com/drduh/config/662c16404eef04f506a6a208f1253fee2f4895d9/gpg.conf";
-    sha256 = "118fmrsn28fz629y7wwwcx7r1wfn59h3mqz1snyhf8b5yh0sb8la";
-  }} "$GNUPGHOME/gpg.conf"
-    sudo cat << EOF > $GNUPGHOME/gpg-agent.conf
-    pinentry-program /run/current-system/sw/bin/pinentry-curses
-    EOF
-    sudo chown nixos:users $GNUPGHOME/gpg-agent.conf
-    sudo chmod 644 $GNUPGHOME/gpg-agent.conf
-    echo "\$GNUPGHOME has been set up for you. Generated keys will be in $GNUPGHOME."
+      export GNUPGHOME=/run/user/$(id -u)/gnupghome
+      if [ ! -d $GNUPGHOME ]; then
+      mkdir $GNUPGHOME
+      fi
+      sudo cp ${pkgs.fetchurl {
+      url = "https://raw.githubusercontent.com/drduh/config/662c16404eef04f506a6a208f1253fee2f4895d9/gpg.conf";
+      sha256 = "118fmrsn28fz629y7wwwcx7r1wfn59h3mqz1snyhf8b5yh0sb8la";
+    }} "$GNUPGHOME/gpg.conf"
+      sudo cat << EOF > $GNUPGHOME/gpg-agent.conf
+      pinentry-program /run/current-system/sw/bin/pinentry-curses
+      EOF
+      sudo chown nixos:users $GNUPGHOME/gpg-agent.conf
+      sudo chmod 644 $GNUPGHOME/gpg-agent.conf
+      echo "\$GNUPGHOME has been set up for you. Generated keys will be in $GNUPGHOME."
   '';
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,8 +1,8 @@
 self: super:
 {
-  flasksample = super.callPackage ./pkgs/flasksample {};
-  sshcb = super.callPackage ./pkgs/sshcb {};
-  codefresh = super.callPackage ./pkgs/codefresh {};
-  aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator {};
-  terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect {};
+  flasksample = super.callPackage ./pkgs/flasksample { };
+  sshcb = super.callPackage ./pkgs/sshcb { };
+  codefresh = super.callPackage ./pkgs/codefresh { };
+  aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator { };
+  terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect { };
 }

--- a/pin/default.nix
+++ b/pin/default.nix
@@ -1,4 +1,4 @@
-{ bootstrap ? import <nixpkgs> {}
+{ bootstrap ? import <nixpkgs> { }
 , snapshot
 }:
 let
@@ -9,4 +9,4 @@ let
     inherit (nixpkgs) rev sha256;
   };
 in
-import src {}
+import src { }

--- a/pin/generate_pin
+++ b/pin/generate_pin
@@ -6,7 +6,7 @@
 
 set -eufo pipefail
 
-REPO='nixpkgs-channels'
+REPO='nixpkgs'
 OWNER='NixOS'
 ITER='0'
 
@@ -51,7 +51,7 @@ do
 done
 shift $((OPTIND -1))
 
-GITREF=${1:-'nixos-unstable'}
+GITREF=${1:-'master'}
 PINOUT="./pins/${GITREF}_${ITER}.json"
 
 test -f $PINOUT && echo "$PINOUT already exists" && exit 1

--- a/pin/pins/nixos-unstable_0.json
+++ b/pin/pins/nixos-unstable_0.json
@@ -1,9 +1,0 @@
-{
-  "url": "https://github.com/NixOS/nixpkgs-channels.git",
-  "rev": "b61999e4ad60c351b4da63ae3ff43aae3c0bbdfb",
-  "date": "2020-04-16T12:43:36Z",
-  "sha256": "0cggpdks4qscyirqwfprgdl91mlhjlw24wkg0riapk5f2g2llbpq",
-  "fetchSubmodules": false,
-  "deepClone": false,
-  "leaveDotGit": false
-}

--- a/pin/pins/release-21.05_0.json
+++ b/pin/pins/release-21.05_0.json
@@ -1,0 +1,9 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "001f78ff0044adf3ca972643eaf3fc5cbc8f634c",
+  "date": "2021-06-24T09:25:01Z",
+  "sha256": "0yglg4cdn8xgz1zkc22vlmgy1s766imqziyc0xfvrak3bgd0jm1i",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/codefresh/yarn.nix
+++ b/pkgs/codefresh/yarn.nix
@@ -2779,11 +2779,11 @@
             sha256 = "1f9vzaxnkq9yh6sb5mbcnqgfk21icckabhc971f6ai8jr0sxhqn7";
           };
         in
-          runCommandNoCC "firebase.git" { buildInputs = [ gnutar ]; } ''
-            # Set u+w because tar-fs can't unpack archives with read-only dirs
-            # https://github.com/mafintosh/tar-fs/issues/79
-            tar cf $out --mode u+w -C ${repo} .
-          '';
+        runCommandNoCC "firebase.git" { buildInputs = [ gnutar ]; } ''
+          # Set u+w because tar-fs can't unpack archives with read-only dirs
+          # https://github.com/mafintosh/tar-fs/issues/79
+          tar cf $out --mode u+w -C ${repo} .
+        '';
     }
     {
       name = "flat_cache___flat_cache_1.3.4.tgz";

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import ./pin { snapshot = "nixos-unstable_0"; };
+with import ./pin { snapshot = "release-21.05_0"; };
 
 mkShell {
   buildInputs = [


### PR DESCRIPTION
## Description of PR

The `nix-shell` pin has quite old and needs to be updated before we do any further work on unpinning the imgs we are building. This is to check to see how reproducible out results are given updates in the tool chain. I suspect for what we are leveraging it will be minimal but want to see how it behaves while we have the opportunity.

## Previous Behavior
- Pin for nix-shell was point to old pin that came for now deprecated nix channel repo

## New Behavior
- Pin point to latest release branch 21.05
- nixpkgs-fmt has new requirements that needed to be accounted for: `find . -name "*.nix"| xargs nixpkgs-fmt`

## Tests
- `publish` to see how the imgs build inside this new `nix-shell`
- Results `publish` of imgs remained stable as expected: 
`flasksample` - https://github.com/Nebulaworks/nix-garage/runs/3146948986?check_suite_focus=true#step:6:287
`helmsman-aws` - https://github.com/Nebulaworks/nix-garage/runs/3146948986?check_suite_focus=true#step:6:317
`magic-wormhole-mailbox` - https://github.com/Nebulaworks/nix-garage/runs/3146948986?check_suite_focus=true#step:6:359
`pki-validator` - https://github.com/Nebulaworks/nix-garage/runs/3146948986?check_suite_focus=true#step:6:390
