### PR TITLE
[READY] - Enable daily builds of our container images

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,28 @@
+name: Daily Run
+
+on:
+  schedule:
+    - cron: '17 15 * * *' # Build every day
+  workflow_dispatch:
+  
+jobs:
+  upstream_nixpkgs:
+    name: 'Build images off master'
+    runs-on: ubuntu-18.04
+    # Utilizing nixos/nix docker image v2.3.12
+    container:
+      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
+    
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        with:
+          ref: master
+      - name: 'Publish off latest nixpkgs master'
+        run: |
+          # Beware of quoting here
+          sha=$(nix-shell --run "curl --request GET --url 'https://api.github.com/repos/nixos/nixpkgs/commits?per_page=1' -H 'Accept: application/vnd.github.v3+json' | jq -r '.[0].sha'")
+          export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/${sha}.tar.gz
+          # No need to create docker repos since we can assume they exist
+          # just publish here
+          nix-shell --run 'bash ./publish-imgs.sh'

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -121,21 +121,14 @@ jobs:
           export REGISTRY_AUTH_FILE=$GITHUB_WORKSPACE/auth.json
 
           cd $GITHUB_WORKSPACE
-          allImgs=""
-          for currImgPath in $(ls -d $GITHUB_WORKSPACE/imgs/*/); do
-            currImgName=$(basename $currImgPath)
-            if [ -z $allImgs ]; then
-              allImgs="$currImgName"
-            else
-              allImgs="$allImgs, $currImgName"
-            fi
-
-            set +x
-            nix-shell --run "cd $GITHUB_WORKSPACE && \
-            ./create-repo $DOCKER_HUB_TOKEN nebulaworks $currImgName && \
-            ./publish-imgs $currImgName"
-            set -x
+          # use drvs to find all images we would want to build
+          IMAGES=$(nix-shell --run "nix-instantiate --eval --strict --json -A imgs | jq -r 'keys[]'")
+          for image in ${IMAGES}; do
+            nix-shell --run "./create-repo $DOCKER_HUB_TOKEN nebulaworks $image"
           done
+
+          # Check to see what images we have to build
+          allImgs=$(nix-shell --run "./publish-imgs")
           echo ::set-output name=allImgs::$allImgs
         continue-on-error: false
 

--- a/publish-imgs
+++ b/publish-imgs
@@ -9,6 +9,9 @@ registry="docker.io"
 # if not just build all imgs
 attr=${1:-'imgs'}
 
+# For storing all built and published images
+BUILT=()
+
 for entry in $(nix-instantiate -A $attr); do
   derivation=$(nix show-derivation $entry)
   image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
@@ -25,5 +28,12 @@ for entry in $(nix-instantiate -A $attr); do
   # We can use the drv here since we dont have the attribute path
   nix-build $entry
   skopeo --insecure-policy copy docker-archive:result docker://${registry_endpoint}
+  BUILT+=("$image_name:${calcout}")
 done
 
+if [ ${#BUILT[@]} -eq 0 ]; then
+  echo "Nothing to do"
+else
+  # Print built images:out comma separated if we built things
+  (IFS=,; echo "${BUILT[*]}")
+fi

--- a/publish-imgs
+++ b/publish-imgs
@@ -3,20 +3,27 @@
 # shellcheck shell=bash
 set -efo pipefail
 
-test -z $1 && (echo "pass in img" && exit 1)
-
-derivation=$(nix show-derivation $(nix-instantiate -A imgs.$1))
 registry="docker.io"
-image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
-org=$(echo $image_fullname | cut -d '/' -f 1)
-image_name=$(echo $image_fullname | cut -d '/' -f 2)
-calcout=$(echo $derivation | jq '.[] | .env.out')
-calcout=$(basename ${calcout} | cut -d '-' -f1)
-registry_endpoint="${registry}/${org}/${image_name}:${calcout}"
 
-# Check if this image is already in the registry and exit if so
-skopeo inspect docker://${registry_endpoint} && exit 0
+# Assume that we will pass in attribute path, i.e. imgs.awsutils
+# if not just build all imgs
+attr=${1:-'imgs'}
 
-nix-build -A imgs.$1
+for entry in $(nix-instantiate -A $attr); do
+  derivation=$(nix show-derivation $entry)
+  image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
+  org=$(echo $image_fullname | cut -d '/' -f 1)
+  image_name=$(echo $image_fullname | cut -d '/' -f 2)
+  calcout=$(echo $derivation | jq '.[] | .env.out')
+  calcout=$(basename ${calcout} | cut -d '-' -f1)
+  registry_endpoint="${registry}/${org}/${image_name}:${calcout}"
 
-skopeo --insecure-policy copy docker-archive:result docker://${registry_endpoint}
+  # Check if this image is already in the registry and if so continue to next item in the list
+  skopeo inspect docker://${registry_endpoint} && continue
+
+  # I guess we need to build and push this to the registry if weve made it this far
+  # We can use the drv here since we dont have the attribute path
+  nix-build $entry
+  skopeo --insecure-policy copy docker-archive:result docker://${registry_endpoint}
+done
+


### PR DESCRIPTION
## Description of PR

We can now enable building out container images daily off of the upstream nixpkgs. This will allow us to have very up to date images published to dockerhub without us having to bump pins, etc.

In addition to these changes I have updated some of the other scripts and workflows to help simplify there function and leverage some the functionality thats built into `nix` (`nix-instantiate` for example)

## Previous Behavior
- No daily container image builds were happening in our workflows
- `publish_imgs` workflow we were leveraging file names instead of nix attributes
- `publish_imgs` workflow returns all images for every run via comment

## New Behavior
- Leverage nix path attributes for `publish_imgs` in the case where we have multiple images that come from a single drv (not the case yet but absolutely possible in the future)
- During `publish_imgs` workflow only return images that were built and published
- Enable daily build of container images referencing `latest` upstream commit off nixpkgs `master`

## Tests
- Tested daily built in separate actions repo (private)
- Tested changes to publish-imgs locally, but commented out `skopeo copy` since Id rather have those things take place via CI