### PR TITLE
[REVIEW] - Correct file path for publish-imgs daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,4 +25,4 @@ jobs:
           export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/${sha}.tar.gz
           # No need to create docker repos since we can assume they exist
           # just publish here
-          nix-shell --run 'bash ./publish-imgs.sh'
+          nix-shell --run 'bash ./publish-imgs'


### PR DESCRIPTION
## Description of PR

`publish-imgs.sh` should be `publish-imgs`

## Previous Behavior
- Wrong file name

## New Behavior
- Correct file name

## Tests
- Run workflow via dispatch
