### PR TITLE
[READY] Adding missing auth for daily build

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '17 15 * * *' # Build every day
   workflow_dispatch:
-  
+
 jobs:
   upstream_nixpkgs:
     name: 'Build images off master'
@@ -12,7 +12,7 @@ jobs:
     # Utilizing nixos/nix docker image v2.3.12
     container:
       image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
-    
+
     steps:
       - name: 'Checkout'
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -20,6 +20,18 @@ jobs:
           ref: master
       - name: 'Publish off latest nixpkgs master'
         run: |
+          # Just need auth.json for skopeo
+          cat << EOF > ./auth.json
+          {
+            "auths": {
+              "https://index.docker.io/v1/": {
+                "auth": "$(echo -n 'nwiauto:${{ secrets.NWIAUTO_PASSWORD }}' | base64)"
+              }
+            }
+          }
+          EOF
+          export REGISTRY_AUTH_FILE=./auth.json
+
           # Beware of quoting here
           sha=$(nix-shell --run "curl --request GET --url 'https://api.github.com/repos/nixos/nixpkgs/commits?per_page=1' -H 'Accept: application/vnd.github.v3+json' | jq -r '.[0].sha'")
           export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/${sha}.tar.gz


### PR DESCRIPTION
## Description of PR

We were missing auth... Of course!

## Previous Behavior
- `daily` build workflow failed due to missing `auth.json`:  https://github.com/Nebulaworks/nix-garage/runs/3510324797?check_suite_focus=true

## New Behavior
- Now we have `auth.json` and can publish to docker hub: https://github.com/Nebulaworks/nix-garage/runs/3510354593
- Also confirmed that are still only pushing images we have already built: https://github.com/Nebulaworks/nix-garage/actions/runs/1199583937

## Tests
- `Daily workflow` success and resulting in newly images published to dockerhub:

```
awsutils:hx1a61jwx4r2crri7iph7ygd19gbqab5,flasksample:zzpm4r45shaicn75lgvlnhxfqk3rgm9x,helmsman-aws:paks7yd7laypwmpg3i3mbvw937hdgdnc,magic-wormhole-mailbox:lizc5jamh39zy5xm4cjhnd3a9v3gxzm9,pki-validator:s1l8jmzblv13rnzs9ggsd2xrssalj52a
```
