### PR TITLE
[READY] - Init git-divergence from orion

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,7 @@
 self: super:
 {
   flasksample = super.callPackage ./pkgs/flasksample { };
+  git-divergence = super.callPackage ./pkgs/git-divergence { };
   sshcb = super.callPackage ./pkgs/sshcb { };
   codefresh = super.callPackage ./pkgs/codefresh { };
   aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator { };

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,9 +1,9 @@
 self: super:
 {
+  aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator { };
+  codefresh = super.callPackage ./pkgs/codefresh { };
   flasksample = super.callPackage ./pkgs/flasksample { };
   git-divergence = super.callPackage ./pkgs/git-divergence { };
   sshcb = super.callPackage ./pkgs/sshcb { };
-  codefresh = super.callPackage ./pkgs/codefresh { };
-  aws-key-rotator = super.callPackage ./pkgs/aws-key-rotator { };
   terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect { };
 }

--- a/pkgs/git-divergence/default.nix
+++ b/pkgs/git-divergence/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+let
+  src = fetchFromGitHub {
+    owner = "nebulaworks";
+    rev = "7784e742393ab3745aa19b4c999b17e768393271";
+    repo = "orion";
+    sha256 = "0c46fjvgyn85x4pl2jwcqbmzi4k7pnnik9rvy0ql6k29d2agdya1";
+  };
+in
+python3Packages.buildPythonPackage rec {
+  # drv still needs src even though application is in subdir
+  inherit src;
+  pname = "git-divergence";
+  version = "0.2.0";
+
+  # Need to look at the subdirectory since theres multiple scripts here
+  sourceRoot = "${src.name}/scripts/git_divergence";
+
+  propagatedBuildInputs = with python3Packages; [ gitdb GitPython smmap ];
+
+  # Will use version for upstream
+  # TODO: should fix strictness of setup.py
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "gitdb==4.0.5" "gitdb"
+    substituteInPlace requirements.txt --replace "GitPython==3.1.11" "GitPython"
+    substituteInPlace requirements.txt --replace "smmap==3.0.4" "smmap"
+  '';
+
+  meta = with lib; {
+    description = "Outline stale/outdated unmerged remote branches in a given Git Repository";
+    license = licenses.bsd3;
+    maintainers = "NWI";
+  };
+}


### PR DESCRIPTION
## Description of PR

Needed to use https://github.com/Nebulaworks/orion/tree/main/scripts/git_divergence for something and wanted it installed via nixpkgs :slightly_smiling_face: 

## Previous Behavior
- `git_divergence` didnt exist in nix-garage as a nixpkg

## New Behavior
- `git_divergence` exists in the nix-garage overlay :partying_face: 

## Tests
- Tested again this repo:
```
$ nix-shell -p "with import ./default.nix {}; pkgs.git-divergence"
$ GIT_REPO_PATH=. divergence                                            
Repo at . successfully loaded.                     
Repo description: Unnamed repository; edit this file 'description' to name the repository.
Remote named "upstream" with URL "git@github.com:Nebulaworks/nix-garage.git"
Branch                    Behind   Ahead   DSB  DSLC DIVERGENCE                                          
upstream/rh/gl-issue-460    22       1      91    91        0
refs/stash                  5        2      24    24        0
