### PR TITLE
[READY] - init upgrade-eks-workers@08-31-2021

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -7,4 +7,5 @@ self: super:
   sshcb = super.callPackage ./pkgs/sshcb { };
   term-apply = super.callPackage ./pkgs/term-apply { };
   terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect { };
+  upgrade-eks-workers = super.callPackage ./pkgs/upgrade-eks-workers { };
 }

--- a/pkgs/upgrade-eks-workers/default.nix
+++ b/pkgs/upgrade-eks-workers/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, pkgs
+}:
+let
+  src = fetchFromGitHub {
+    owner = "nebulaworks";
+    rev = "7784e742393ab3745aa19b4c999b17e768393271";
+    repo = "orion";
+    sha256 = "0c46fjvgyn85x4pl2jwcqbmzi4k7pnnik9rvy0ql6k29d2agdya1";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit src;
+  pname = "upgrade-eks-workers";
+  version = "08-31-2021";
+
+  sourceRoot = "${src.name}/scripts";
+
+  propagatedBuildInputs = with pkgs; [ awscli2 kubectl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp upgrade-eks-workers.sh $out/bin/upgrade-eks-workers
+    chmod +x $out/bin/upgrade-eks-workers
+  '';
+
+  meta = with lib; {
+    description = "Upgrade EKS cluster worker nodes by draining and terminating a single instance at a time";
+    license = licenses.bsd3;
+    maintainers = "NWI";
+  };
+}


### PR DESCRIPTION
## Description of PR

Adding in pkg from orion for upgrading eks workers: https://github.com/Nebulaworks/orion/blob/main/scripts/upgrade-eks-workers.sh

## Previous Behavior
- pkg was no in overlay

## New Behavior
- pkg is now in the overlay

## Tests
- Script built and available in overlay:

```
$ nix-build -A pkgs.upgrade-eks-workers
$ ./result/bin/upgrade-eks-workers -h
Usage: REGION=<region> AWS_PROFILE=<profile> upgrade-eks-workers <cluster_name>

Upgrade EKS cluster worker nodes by draining and terminating a single instance at a time.

This script requires ~10.5min to cycle EKS worker nodes.


ENVIRONMENT VARIABLES REQUIRED:

  REGION            the AWS region your cluster is deployed to
  AWS_PROFILE       an AWS profile to access your cluster


EXAMPLE:

  REGION=us-west-2 AWS_PROFILE=nwi-eks-admin ./upgrade-eks-workers.sh <cluster_name>
```