### PR TITLE
[READY] - Update release.nix automatically based on daily build results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Nebulaworks Engineering use of [nixpkgs](https://github.com/NixOS/nixpkgs)
 * [Publishing](./PUBLISHING.md)
 * [iso Configs](./isos/README.md)
 * [Templates](./templates/README.md)
+* [Release](./RELEASE.md)
 
 ## Building Nix Configurations
 While there are numerous ways of building Nix configurations, one way to build nix configs in a non-linux environment is

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,40 @@
+# Release
+
+## Updating release.nix
+
+Update the `pin` off of the last successful build:
+
+```
+nix-shell
+cd pin
+./update_release
+```
+
+Then check to ensure that all `imgs` are already published to the registry:
+
+```
+nix-shell
+./publish-imgs -f release.nix -s imgs
+```
+
+The result should be:
+
+```
+Nothing to do
+```
+> This is because we already built the images as part of our `Daily Run` CI job.
+
+Submit a PR with the changes generated
+
+## Create release refs
+
+After updating the `release.nix` and this has been merged to `master` we can then create
+our refs:
+
+```
+git checkout master
+git pull --rebase origin master
+git checkout -b RC/<num>
+git tag -a -m "Release <num>" <num> # Tag always cut from RC/
+git push origin RC/<num> --tags
+```

--- a/pin/generate_pin
+++ b/pin/generate_pin
@@ -19,7 +19,8 @@ Generate pins from nix channels
 
 OPTIONS:
   -h      Show this message
-  -i      set iteration
+  -i      set pin iteration
+  -r      set specific nixpkg rev/commit to use
 
 EXAMPLES:
   Generate nix pin from nixos-20.03 branch:
@@ -33,7 +34,7 @@ EXAMPLES:
 EOF
 }
 
-while getopts "hi:" OPTION
+while getopts "hi:r:" OPTION
 do
   case $OPTION in
     i )
@@ -42,6 +43,9 @@ do
     h )
       usage
       exit 0
+      ;;
+    r )
+      REV=$OPTARG
       ;;
     \? )
       usage
@@ -56,9 +60,14 @@ PINOUT="./pins/${GITREF}_${ITER}.json"
 
 test -f $PINOUT && echo "$PINOUT already exists" && exit 1
 
-APIRESP=$(curl "https://api.github.com/repos/$OWNER/$REPO/branches/$GITREF" | jq -r '.')
-REVDATE=$(echo ${APIRESP} | jq -r '.commit.commit.author.date')
-REV=$(echo ${APIRESP} | jq -r '.commit.sha')
+if [ -z ${REV} ]; then
+  APIRESP=$(curl "https://api.github.com/repos/$OWNER/$REPO/branches/$GITREF" | jq -r '.')
+  REV=$(echo ${APIRESP} | jq -r '.commit.sha')
+  REVDATE=$(echo ${APIRESP} | jq -r '.commit.commit.author.date')
+else
+  APIRESP=$(curl "https://api.github.com/repos/$OWNER/$REPO/commits/$REV" | jq -r '.')
+  REVDATE=$(echo ${APIRESP} | jq -r '.commit.author.date')
+fi
 
 SHA256=$(nix-prefetch-url --unpack "https://github.com/$OWNER/$REPO/archive/$REV.tar.gz")
 JQOUT=$(jq -n '{url: $url, rev: $rev, date: $date,  sha256: $sha256, fetchSubmodules: false, deepClone: false, leaveDotGit: false}' \

--- a/pin/pins/master_0.json
+++ b/pin/pins/master_0.json
@@ -1,0 +1,9 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "3ef1d2a9602c18f8742e1fb63d5ae9867092e3d6",
+  "date": "2021-10-20T15:05:21Z",
+  "sha256": "0yicccl89rfa5nk4ic46ydihvzsw1phzsypnlzmzrdnwsxi3r9d4",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pin/update_release
+++ b/pin/update_release
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# This script takes care of the following tasks:
+#
+# - Grabs the latest successful daily build of our nix imgs using
+#   nixpkgs master
+# - It generates a new pin off that same point commit off nixpkgs
+# - Ensures the reference in release.nix is pointing to the correct pin
+#
+# You will need to `export GITHUB_TOKEN` since it has to query the github api
+# for metadata about the github actions runs
+
+UPSTREAM_BRANCH="master"
+ITERATION="0"
+PIN_NAME=${UPSTREAM_BRANCH}_${ITERATION}
+TMP_ZIP=$(mktemp)
+
+[ -z "${GITHUB_TOKEN}" ] && echo "Please 'export GITHUB_TOKEN='" && exit 1
+
+# Clean up tmp zip on exit
+trap "rm -f ${TMP_ZIP}" EXIT
+
+
+# Get latest run of workflow off master
+# run_id == id here not run_number :/
+RUN_ID=$(curl -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/nebulaworks/nix-garage/actions/runs | \
+              jq '.workflow_runs | [ .[] | select( (.head_branch == "master") and (.name == "Daily Run") and (.conclusion == "success"))] | .[0].id ')
+
+# Apparently unzip cant use pipes so well have to write this out to the temp location
+# See `man zip` BUGS section:
+# [Unix]  Unix special files such as FIFO buffers (named pipes), block devices and character devices are not restored
+# even if they are somehow represented in the zipfile, nor are hard-linked files relinked. Basically the only file types
+# restored by unzip are regular files, directories and symbolic (soft) links.
+GRAB_LOGS=$(curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 https://api.github.com/repos/Nebulaworks/nix-garage/actions/runs/${RUN_ID}/logs \
+                 --output $TMP_ZIP)
+
+# Being lazy...
+# TODO: Shell golf
+# TODO: echoing a uniquer string during daily run is probably going to be better
+LATEST_BUILD_HASH=$(unzip -c $TMP_ZIP "Build images off master/4_Publish off latest nixpkgs master.txt" | grep -m 1 .unpacking | cut -d . -f3 | cut -d / -f5)
+
+echo "Found: $LATEST_BUILD_HASH"
+
+# If pin exists we assume it can be overwritten
+test -f pins/$PIN_NAME.json && rm pins/$PIN_NAME.json
+
+# Make a nice pin json ref
+./generate_pin -i $ITERATION -r $LATEST_BUILD_HASH $UPSTREAM_BRANCH
+
+# Update the release.nix to make sure that we are referring to this pin
+sed -i "s/\(snapshot[[:space:]]=[[:space:]]\)\".*\"/\1\"$PIN_NAME\"/" ../release.nix

--- a/publish-imgs
+++ b/publish-imgs
@@ -4,6 +4,48 @@
 set -efo pipefail
 
 registry="docker.io"
+nixtop="default.nix"
+
+# shellcheck disable=SC2148
+usage(){
+  cat << EOF
+usage: $(basename "$0") [OPTIONS] ATTR
+
+Check if images are in docker hub and publish if necessary
+
+OPTIONS:
+  -h      Show this message
+  -f      Set top-level nix file, default.nix otherwise
+  -s      Skip pushing to registry
+
+EXAMPLES:
+  Leverage release.nix instead of default.nix to publish:
+
+      $(basename "$0") -f release.nix
+
+EOF
+}
+
+while getopts "f:hs" OPTION
+do
+  case $OPTION in
+    f )
+      nixtop=$OPTARG
+      ;;
+    h )
+      usage
+      exit 0
+      ;;
+    s )
+      skip_publish=1
+      ;;
+    \? )
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
 
 # Assume that we will pass in attribute path, i.e. imgs.awsutils
 # if not just build all imgs
@@ -12,8 +54,8 @@ attr=${1:-'imgs'}
 # For storing all built and published images
 BUILT=()
 
-for entry in $(nix-instantiate -A $attr); do
-  derivation=$(nix show-derivation $entry)
+for entry in $(nix-instantiate -A $attr $nixtop); do
+  derivation=$(nix show-derivation -f $nixtop $entry)
   image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
   org=$(echo $image_fullname | cut -d '/' -f 1)
   image_name=$(echo $image_fullname | cut -d '/' -f 2)
@@ -24,9 +66,11 @@ for entry in $(nix-instantiate -A $attr); do
   # Check if this image is already in the registry and if so continue to next item in the list
   skopeo inspect docker://${registry_endpoint} && continue
 
+  # Skip publishing to registry if this flag is set
+  [[ ! -z $skip_publish ]] && echo "Would have published: ${image_name}" && continue
   # I guess we need to build and push this to the registry if weve made it this far
   # We can use the drv here since we dont have the attribute path
-  nix-build $entry
+  nix-build -A $entry $nixtop
   skopeo --insecure-policy copy docker-archive:result docker://${registry_endpoint}
   BUILT+=("$image_name:${calcout}")
 done

--- a/release.nix
+++ b/release.nix
@@ -3,7 +3,7 @@
 
 {}:
 let
-  nixpkgs = import ./pin { snapshot = "release-21.05_0"; };
+  nixpkgs = import ./pin { snapshot = "master_0"; };
   default = import ./default.nix { inherit nixpkgs; };
 in
 default


### PR DESCRIPTION
## Description of PR
Considering we are daily building our containers: https://github.com/Nebulaworks/nix-garage/actions/workflows/daily.yml

We need a way to point to the last successful build of our containers for a release

## Previous Behavior
- No automated way to update `release.nix`

## New Behavior
- Run `update_release` to get latest daily build results from github action
- Update the refs accordingly for pin and release.nix
- Updated `publish-imgs` to support more than just `default.nix` toplevel
- Initialized release docs

## Tests
- pr comment image build returns no new results since we already built them off previous daily build :)

- `./publish-imgs -f release.nix -s imgs` Confirms thats theres no publishing necessary :)
```
{
    "Name": "docker.io/nebulaworks/awsutils",
    "Digest": "sha256:b767d0070b5136f7576f222c4b01c00cb0bb1aa5241c3fd598477c0b480e3354",
    "RepoTags": [
        "0afjz2x6jzlqbyp6hlsn7xx1j4v595xj",
        "1hx4387bjv85cs424znxr9fpbdbm8djk",
        "43pax9ygdpviwka1lvqkvsxk3qlkg32i",
        "4iyc3wm1kjz9lwqwsgvjz8g78hdgxc7p",
        "4yzrc2fjyajqaihgn3jycfjjsrwrdb7z",
        "5dq3sxqy6ql24adppr4abllkpq51ai25",
        "9jfmk9gq677qhks1nagk6kagr21b80zh",
        "a2x2gakpv9acj1zp6q4cfk0x34kakh84",
        "b2xpdz7r5fdlnyyalsxlzncwlvy1gh6m",
        "c3skllz0pvp6a78nf3c4fck7xcg1yxq5",
        "dz783iaashdby6phqf9pcydxsw1bbjq0",
        "g44npkrgrh2qj2y9j1a9n6frcyd2j45z",
        "hbqmiwillbddpzdjdl0v8y5h1xxy1bwx",
        "hx1a61jwx4r2crri7iph7ygd19gbqab5",
        "ib0v6zkv2qqaidwda7sp64pa0jfc0vbs",
        "k2c75rki35d8z8giwynras8nwrsr1l0z",
        "k3i9bp4w5ndn7ai6cylbimxybqln4nrc",
        "vbp6wk6y3gn143g5sfsfgpih8shr2sml",
        "w4cwy90aa2b1rrf9nqd5qjcflrjh0129"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "awscli:1.20.54,bash:5.1,coreutils:8.32,curl:7.76.1,git-lfs:2.13.3,git:2.33.0,gnutar:1.34,gzip:1.10,jq:1.6,nss-cacert:3.66",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:65fe2b12d995ecb1e6e54d8e4ad8c43ab9c94cf5e9dbf29fecc4854ae9082d5d"
    ],
    "Env": [
        "PATH=/bin/",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
    ]
}
{
    "Name": "docker.io/nebulaworks/flasksample",
    "Digest": "sha256:29068b55b8789e1a7cba22707dd523ba53e274e728d00f61737efc9c3d5ad0af",
    "RepoTags": [
        "5fi5d6s9qb0ayfxvd4czrwvrk0jv9q1r",
        "65j7jsrql5qicfadj3dqbinyaaisi5sg",
        "68rag50ayc9gsi7n4bwdbjq0ah2pcs0a",
        "8wp5sb35h86bygxchcv9cgcsxzh2dc5p",
        "aggzwxjm6v6jfbjbwn1z0fvfp0xiqid6",
        "biayqv0sg5v36dvnl7yh6gg941gl0ba6",
        "fwwz8b6jm0q8m2w0lgw68mila23r08cp",
        "iiij8fj3jib4qyf6dzm64a9c79wrhk71",
        "kxhq2jcijnkp8qhnlhy47023jcd0rj52",
        "mk0ldb79sxm75wy99zk195dngl3dk5k0",
        "rzk3f7a3w0ww8rlzi3401z3bz4mkmrn4",
        "zzpm4r45shaicn75lgvlnhxfqk3rgm9x"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "bash:5.1,coreutils:8.32,flasksample:0.1.0",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:4272eb7e65232de37f27de62cf02273d42840c15f0515709c7d168359c35dd4a"
    ],
    "Env": []
}
{
    "Name": "docker.io/nebulaworks/helmsman-aws",
    "Digest": "sha256:21a5694b4098cfd279787bc96e40dcc35a8dcc6b11bd14d893f367b33d753223",
    "RepoTags": [
        "0r4rskk3b5han0zzncj67sjhkm7lip1w",
        "2vil2iz4gz0lmcqsg92kxylhh4mds6jv",
        "72rs42ar65syxrgq6w0qyv98n97zkr6n",
        "7ar2sigpxxyll06yvgan428qn74k0vqm",
        "7hl8p275d7f3gcnam52s7hg1d307a2ik",
        "7mc83swh71lgji4ar8fz8a1n13zq934p",
        "91hn17cblaiv1wb26vvwz05m3787c4zv",
        "9xnr8m6mj35mh6fwxx1nsxp11arvm1sh",
        "a5kn44776qgdm8dgjmlym4z79qhnm6mn",
        "axk5j5bhv0sv9ys1xj4bmhc34kfw5jkn",
        "ibx9pd0yzvspf6gczmdmmhmam9sr25wr",
        "k345a553cr4aicxcl9l7ns2rjzhiv62v",
        "l0mz1yxw70ab4kmqnvjbcxklm088q7l8",
        "m9kvdhzskjmvd6lbrmx9n195cm08amgq",
        "paks7yd7laypwmpg3i3mbvw937hdgdnc",
        "pbj9q2qyw511wfy18g8lz9jw2mpc5qvw",
        "pfvnzcg5m26m0bd6cj4v6g7j6qndi2m0",
        "rz9fgbx5kvzid11v516zk8l3x31bxph0",
        "sb47bkwd854ws9dc4gzsvnln06pidxjf",
        "sgv2bi85zdbbznixhpck8w5c29np1w87",
        "v4mlmsr2lpvjh3pykpg3b3755zsp5yip",
        "vibjzpbdqxyfxppd37sy8sskbn9knd10",
        "xym39zji91ga5rbw6p8xbwy5dcbizbn3",
        "zmz5fxsfpmjdf28mmknxaqwp9ig4kyxa"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "awscli:1.20.54,bash:5.1,coreutils:8.32,helm:3.7.0,helmsman:3.7.5,jq:1.6,kubectl:1.22.2,nss-cacert:3.66",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:c86efd19245a2d5a450508c581304613fd5a2dd0678b79acfa348fc2e7d5b05c"
    ],
    "Env": [
        "PATH=/bin/",
        "HELM_PLUGINS=/share/helm/plugins/"
    ]
}
{
    "Name": "docker.io/nebulaworks/magic-wormhole-mailbox",
    "Digest": "sha256:967c160c3a1cfa73298052b4bbecf48c17a1c2308f13ff56f874d0af04df362a",
    "RepoTags": [
        "3qsccb3a1wv9rrf5vvj7cpv1inmi1ah0",
        "689cg14skn51dqs5rad4579lajq8qa32",
        "705kflnqwjdm0faxwf9rwsynglb51mi8",
        "7pdcv4l8yszm7s1za0xd06pbnhqqdjwm",
        "9s06afg8b3sgnq8mdx0g5sz6377ai8cb",
        "dmlj2inrm7af7mfc412jkdn6n1s9hg3h",
        "f5d5asfq9a7d4969bpxn2l9x2p5x5gfb",
        "i4aiffyr6501ism0si9jvp2ggi89x08k",
        "jf9w4rj0gz8qnbnwwqcsrzp1bnmrw009",
        "lizc5jamh39zy5xm4cjhnd3a9v3gxzm9",
        "msahb86b470r5636v8imzs8sghgzg38b",
        "njf33wky3rf1fpfzs4f42nn3pzzqsjb7",
        "v57lk1gziq5d5hlkz99yvwzz91di205z",
        "xy3wmckpk7imbj3wv3yw9bfzh6bqyzkk"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "bash:5.1,coreutils:8.32,procps:3.3.16,python3:3.7.11-env",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:9f8835e6f93e8939c69e5c0e206e8adbbb40d0dbb0bd0d4d9642166645c7ceb8"
    ],
    "Env": [
        "PATH=/bin/"
    ]
}
{
    "Name": "docker.io/nebulaworks/pki-validator",
    "Digest": "sha256:339f0767f853aea5d8c6fd8b211301b73ae8d81e3a710c8e882ab147668b8a27",
    "RepoTags": [
        "12x2y4s04wqd7vzblyknmb4i9wlrbyg7",
        "5ydsd6yyfnhilz53bv5f31gwzrpp0yjf",
        "879vbhnlpb9fihpldnlwd6y2cxh449m7",
        "8hs2gsf3n1qq8rlg8md4m3571jkddg8g",
        "bsnlb78w0hpzkx4m7ba40lm0qz2212js",
        "g7hfbpy7vw7xq84zqhqigydyzv60k6s7",
        "h13qqs6wwmkz9g5hb9ca9hnyzchsp2al",
        "hg66vz8gd12bc035xaflv9bvyq9xi9yx",
        "qwcky9z36f8q51kd3rjph1fajmgl7d7n",
        "rwx2sxnrf9b5yyaqyhs28458pzfiw912",
        "s1l8jmzblv13rnzs9ggsd2xrssalj52a"
    ],
    "Created": "1970-01-01T00:00:01Z",
    "DockerVersion": "",
    "Labels": {
        "com.nebulaworks.packages": "bash:5.1,coreutils:8.32,gawk:5.1.0,gnugrep:3.6,gnumake:4.3,openssl:1.1.1l",
        "org.opencontainers.image.authors": "Nebulaworks Inc.",
        "org.opencontainers.image.source": "https://github.com/Nebulaworks/nix-garage"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:cbdd87c34f99232d2240bbee8e5ab994aae374a12abf8fa91a5f38ca3f99086d"
    ],
    "Env": [
        "PATH=/bin/",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
    ]
}
Nothing to do
```
