### PR TITLE
[READY] - [ ISSUE-43 ] - Fixing entry reference for publish-imgs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
         with:
-          ref: master
+          ref: ${{ env.BRANCH }} # should always be master but might be something else if testing
       - name: 'Publish off latest nixpkgs master'
         run: |
           # Just need auth.json for skopeo

--- a/publish-imgs
+++ b/publish-imgs
@@ -47,15 +47,16 @@ do
 done
 shift $((OPTIND -1))
 
-# Assume that we will pass in attribute path, i.e. imgs.awsutils
-# if not just build all imgs
+# Assume that we will pass in attribute path prefix, i.e. imgs
+# TODO: This it technically broken for full attribute paths, i.e imgs.awsutils since the
+# entry we get from the nix-istantiate gets prefixed with the attribute
 attr=${1:-'imgs'}
 
 # For storing all built and published images
 BUILT=()
 
-for entry in $(nix-instantiate -A $attr $nixtop); do
-  derivation=$(nix show-derivation -f $nixtop $entry)
+for entry in $(nix-instantiate --eval --strict --json -A $attr $nixtop | jq -r 'keys[]' ); do
+  derivation=$(nix show-derivation -f $nixtop $attr.$entry)
   image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
   org=$(echo $image_fullname | cut -d '/' -f 1)
   image_name=$(echo $image_fullname | cut -d '/' -f 2)
@@ -70,7 +71,7 @@ for entry in $(nix-instantiate -A $attr $nixtop); do
   [[ ! -z $skip_publish ]] && echo "Would have published: ${image_name}" && continue
   # I guess we need to build and push this to the registry if weve made it this far
   # We can use the drv here since we dont have the attribute path
-  nix-build -A $entry $nixtop
+  nix-build -A $attr.$entry $nixtop
   skopeo --insecure-policy copy docker-archive:result docker://${registry_endpoint}
   BUILT+=("$image_name:${calcout}")
 done


### PR DESCRIPTION
## Description of PR

Fixes: #43

Publishing new imgs to the registry seem to be broken after #41 

```
$ nix-shell --run 'bash -x ./publish-imgs'
...
+ calcout='"/nix/store/0q6n72i9f6w35qg70a8fddnh57jr25yb-docker-image-awsutils.tar.gz"'                                                                                                                              
++ basename '"/nix/store/0q6n72i9f6w35qg70a8fddnh57jr25yb-docker-image-awsutils.tar.gz"'                                                                                                                            
++ cut -d - -f1                                                                                                                                                                                                     
+ calcout=0q6n72i9f6w35qg70a8fddnh57jr25yb                                                                                                                                                                          
+ registry_endpoint=docker.io/nebulaworks/awsutils:0q6n72i9f6w35qg70a8fddnh57jr25yb                                                                                                                                 
+ skopeo inspect docker://docker.io/nebulaworks/awsutils:0q6n72i9f6w35qg70a8fddnh57jr25yb                                                                                                                           
FATA[0001] Error parsing image name "docker://docker.io/nebulaworks/awsutils:0q6n72i9f6w35qg70a8fddnh57jr25yb": Error reading manifest 0q6n72i9f6w35qg70a8fddnh57jr25yb in docker.io/nebulaworks/awsutils: manifest 
unknown: manifest unknown                                                                                                                                                                                           
+ [[ ! -z '' ]]                                                                                                                                                                                                     
+ nix-build -A /nix/store/01ckcym9jmg6q441nxndrx65gddjllg8-docker-image-awsutils.tar.gz.drv default.nix                                                                                                             
error: attribute '/nix/store/01ckcym9jmg6q441nxndrx65gddjllg8-docker-image-awsutils' in selection path '/nix/store/01ckcym9jmg6q441nxndrx65gddjllg8-docker-image-awsutils.tar.gz.drv' not found 
```

Turns out that the nix-build was getting a drv path instead of an actual attribute (i.e. imgs.awsutils): https://github.com/Nebulaworks/nix-garage/blob/28bb3fbe99dcb96e23e13387d42790682400ac5d/publish-imgs#L73

## Previous Behavior
- nix-build was getting a drv path instead of actual attribute when needing to build new images
- daily builds were hard code to `master` branch which wasnt good for testing new functionality via dispatch

## New Behavior
- Fix `nix-build` to leverage attribute from `nix-instantiate`
- Daily builds reference branch they were triggered on

## Tests
- Local builds and publish work
- Will run publishing via `workflow_dispatch`
  - After running daily build via dispatch I had to fix hardcoded refs to `master` but now its all good. Results:
```
awsutils:0wrw13hq33i9lvliwgrilimblm1by6ga,flasksample:xsi7aqn2j1bri2wkgc1zzk159m2dib3f,helmsman-aws:lpsiwff3za9ma0hsvwz9kyvsc8han1nc,magic-wormhole-mailbox:138ca83w6z67cqfj6j3qnrg0cwiq35zg,pki-validator:a78vqgf0nk9m39f9jz56qcqkz3pg85vi
```
  - https://github.com/Nebulaworks/nix-garage/runs/4477240478?check_suite_focus=true
-  Pre-push check is also working for images that we have already built and pushed: https://github.com/Nebulaworks/nix-garage/runs/4477408825?check_suite_focus=true#step:4:515