### PR TITLE
[READY] - [do/issue-456] create nwi-pr-utils image with tfsec and yamllint

### DIFF
--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -9,5 +9,7 @@ rec {
 
   magic-wormhole-mailbox = pkgs.callPackage ./magic-wormhole-mailbox { };
 
+  nwi-pr-utils = pkgs.callPackage ./nwi-pr-utils { };
+
   pki-validator = pkgs.callPackage ./pki-validator { };
 }

--- a/imgs/nwi-pr-utils/README.md
+++ b/imgs/nwi-pr-utils/README.md
@@ -1,0 +1,9 @@
+# nwi-pr-utils
+A lightweight container that contains tools as part of Nebulaworks' internal CI for its repos.
+
+## Contents
+* `tfsec` for Terraform security checking
+* `yamllint` to ensure consistent standards in YAML formatting
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/nwi-pr-utils/default.nix
+++ b/imgs/nwi-pr-utils/default.nix
@@ -1,0 +1,41 @@
+{ system ? builtins.currentSystem, pkgs, fetchFromGitHub }:
+let
+  nwi = import ../../nwi.nix;
+  lib = pkgs.lib;
+
+  # Locking version of tfsec to what it was in the existing GitLab CI job definitions.
+  # TODO: Upgrade to the latest and remediate all new findings.
+  custom-tfsec = pkgs.tfsec.overrideAttrs (oldAttrs: rec {
+    version = "0.39.26";
+    src = fetchFromGitHub {
+      owner = "aquasecurity";
+      rev = "17acbbd9e5628f6ccbe694fc5f368720fb3e4666";
+      repo = "tfsec";
+      sha256 = "QRquQmPOaBEiDX5EvyzMI68mvy3A06l1s1gYXxg5xNM=";
+    };
+    goPackagePath = null;
+    ldflags = null;
+  });
+  contents = with pkgs; [ bash coreutils custom-tfsec yamllint ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/nwi-pr-utils";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+  '';
+  config = {
+    Env = [
+      "PATH=/bin/"
+    ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+  };
+}


### PR DESCRIPTION
## Description of PR
Creating a new image with `yamllint` and `tfsec`. This can be a base image for generic tools that run during our internal repos' CI. I know we needed to create a `yamllint` image anyway to accommodate that tool, but I figure why not assimilate a few other tools under our control and have nix build that image?

## Tests
Testing the build in this PR, then will test this image with the private infra repo's PR.
