### PR TITLE
[READY] - fix nwi-pr-tools tfsec installation

### DIFF
--- a/imgs/nwi-pr-utils/default.nix
+++ b/imgs/nwi-pr-utils/default.nix
@@ -13,10 +13,8 @@ let
       repo = "tfsec";
       sha256 = "QRquQmPOaBEiDX5EvyzMI68mvy3A06l1s1gYXxg5xNM=";
     };
-    goPackagePath = null;
-    ldflags = null;
   });
-  contents = with pkgs; [ bash coreutils custom-tfsec yamllint ];
+  contents = [ pkgs.bash pkgs.coreutils custom-tfsec pkgs.yamllint ];
 in
 pkgs.dockerTools.buildImage {
   inherit contents;


### PR DESCRIPTION
The `tfsec` installation in the `nwi-pr-tools` image didn't work as intended. There was a typo in the `contents` line, and it turns out we probably don't need the overridden `goPackagePath` and `ldflags` attributes.