### PR TITLE
[READY] - update tfsec to latest release

### DIFF
--- a/imgs/nwi-pr-utils/default.nix
+++ b/imgs/nwi-pr-utils/default.nix
@@ -3,18 +3,7 @@ let
   nwi = import ../../nwi.nix;
   lib = pkgs.lib;
 
-  # Locking version of tfsec to what it was in the existing GitLab CI job definitions.
-  # TODO: Upgrade to the latest and remediate all new findings.
-  custom-tfsec = pkgs.tfsec.overrideAttrs (oldAttrs: rec {
-    version = "0.39.26";
-    src = fetchFromGitHub {
-      owner = "aquasecurity";
-      rev = "17acbbd9e5628f6ccbe694fc5f368720fb3e4666";
-      repo = "tfsec";
-      sha256 = "QRquQmPOaBEiDX5EvyzMI68mvy3A06l1s1gYXxg5xNM=";
-    };
-  });
-  contents = [ pkgs.bash pkgs.coreutils custom-tfsec pkgs.yamllint ];
+  contents = [ pkgs.bash pkgs.coreutils pkgs.tfsec pkgs.yamllint ];
 in
 pkgs.dockerTools.buildImage {
   inherit contents;


### PR DESCRIPTION
fixes #47 

## Description of PR
- The github.com/tfsec/tfsec repo references no longer resolve.
- The new repo url is github.com/aquasecurity/tfsec.
- These unresolvable go dependencies break the nix build.
- After our downstream CI has been updated to utilize v0.63.1 (latest) tfsec release, we can merge this PR to fix the broken nix-garage daily build.

## Previous Behavior
daily build is broken: https://github.com/Nebulaworks/nix-garage/runs/4913402701?check_suite_focus=true#step:4:707

## New Behavior
Fixes build
