### PR TITLE
[READY] - add ansible-lint image

### DIFF
--- a/imgs/README.md
+++ b/imgs/README.md
@@ -5,3 +5,11 @@ so that the output of the image is `ALWAYS` reproducible. This has been a long s
 of docker images and `Dockerfile`.
 
 All images are currently hosted in on Dockerhub: https://hub.docker.com/u/nebulaworks
+
+## Local Testing
+
+* The code for your image should be located in `imgs/<image_name>`
+* An entry for your directory should exist in `imgs/default.nix`
+* From the root of the repo run `nix-build -A imgs.<image_name>`
+* Load your output into docker with `docker load < <result_tar_from_previous_step>`
+* Test the created image with `docker run -ti nebulaworks/<image_name>:latest`

--- a/imgs/ansible-lint/README.md
+++ b/imgs/ansible-lint/README.md
@@ -1,0 +1,5 @@
+# ansible-lint
+A lightweight container that has tools for testing python and linting ansible
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/imgs/ansible-lint/default.nix
+++ b/imgs/ansible-lint/default.nix
@@ -1,0 +1,33 @@
+{ system ? builtins.currentSystem, pkgs }:
+let
+  nwi = import ../../nwi.nix;
+  lib = pkgs.lib;
+  customPython = with pkgs; python310.withPackages
+    (pythonPackages: with pythonPackages; [ ansible-lint pylint pytest yamllint ]);
+  contents = with pkgs; [ bash cacert coreutils curl git gnumake jq customPython ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/ansible-lint";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+    mkdir -p usr/bin
+    ln -s ${pkgs.coreutils}/bin/env usr/bin/env
+  '';
+  config = {
+    Env = [
+      "PATH=/bin/"
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+    ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+    WorkingDir = "/";
+  };
+}

--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -1,6 +1,8 @@
 { pkgs }:
 
 rec {
+  ansible-lint = pkgs.callPackage ./ansible-lint { };
+
   awsutils = pkgs.callPackage ./awsutils { };
 
   flasksample = pkgs.callPackage ./flasksample { };

--- a/publish-imgs
+++ b/publish-imgs
@@ -55,6 +55,14 @@ attr=${1:-'imgs'}
 # For storing all built and published images
 BUILT=()
 
+# When using a non-blank ${nixtop} (such as in CI), a new derivation will have to be built
+# during the nix-instantiate in the for loop, because it doesn't yet exist. Having --eval
+# in the command causes it to fail if the dervivation is not yet there. We do the following
+# without --eval and direct its output to /dev/null only as a "pre-populate" step to build
+# the derivation as a work around.
+# TODO: There might be a better way to "pre-generate" the derivation for ci, consider replacing
+nix-instantiate --strict --json -A $attr $nixtop &> /dev/null
+
 for entry in $(nix-instantiate --eval --strict --json -A $attr $nixtop | jq -r 'keys[]' ); do
   derivation=$(nix --extra-experimental-features "nix-command flakes" show-derivation -f $nixtop $attr.$entry)
   image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')


### PR DESCRIPTION
## Description of PR
Adds a new image for `ansible-lint` with some typical complementary tools such as `yamllint`, `pytest`, `pylint`, `jq`, `git`, etc. Immediate use case is for github actions in the CI workflow for [SCaLE network](https://github.com/socallinuxexpo/scale-network/blob/master/.github/workflows/ansible-test.yml). This method seems like a much better alternative to the "standard" [ansible lint github action](https://github.com/ansible/ansible-lint-action/) so others might find it useful. There's also an opportunity to add this to some existing internal projects.

## Tests
- [x] local build and test

```
$ nix-build -A imgs.ansible-lint
/nix/store/b3451xr827aasi99y97j52pnxl6gji5k-docker-image-ansible-lint.tar.gz

$ docker load < /nix/store/b3451xr827aasi99y97j52pnxl6gji5k-docker-image-ansible-lint.tar.gz
Loaded image: nebulaworks/ansible-lint:latest

$ docker run -ti nebulaworks/ansible-lint:latest /bin/bash
bash-5.1# git clone https://github.com/socallinuxexpo/scale-network
Cloning into 'scale-network'...
remote: Enumerating objects: 4552, done.
remote: Counting objects: 100% (585/585), done.
remote: Compressing objects: 100% (346/346), done.
remote: Total 4552 (delta 285), reused 444 (delta 204), pack-reused 3967
Receiving objects: 100% (4552/4552), 861.29 KiB | 4.46 MiB/s, done.
Resolving deltas: 100% (2435/2435), done.
bash-5.1# cd scale-network/facts
bash-5.1# pylint *.py
************* Module datasource
datasource.py:124:10: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
datasource.py:124:10: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)

-----------------------------------
Your code has been rated at 9.78/10

bash-5.1# pytest -vv
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /nix/store/ib89gapvyzncfyjpcwgwikz29jm1iy16-python3-3.10.2-env/bin/python3.10
cachedir: .pytest_cache
rootdir: /scale-network/facts
plugins: flaky-3.7.0
collected 5 items                                                                                                                                                                                                                        

test_datasources.py::test_aplist_csv PASSED                                                                                                                                                                                        [ 20%]
test_datasources.py::test_pilist_csv PASSED                                                                                                                                                                                        [ 40%]
test_datasources.py::test_routerlist_csv PASSED                                                                                                                                                                                    [ 60%]
test_datasources.py::test_serverlist_csv PASSED                                                                                                                                                                                    [ 80%]
test_datasources.py::test_switchtypes_tsv PASSED                                                                                                                                                                                   [100%]

=========================================================================================================== 5 passed in 0.05s ============================================================================================================
bash-5.1# cd ../ansible
bash-5.1# ansible-lint -x 403 -x 503 scale.yml
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: scale.yml
WARNING  Listing 54 violation(s) that are fatal
yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/handlers/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/handlers/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/tasks/main.yml:23

yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/tasks/main.yml:24

yaml: truthy value should be one of [false, true] (truthy)
roles/chrony/tasks/main.yml:25

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:14

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:15

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:16

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:22

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:23

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/handlers/main.yml:24

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:117

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:118

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:119

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:127

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:128

yaml: truthy value should be one of [false, true] (truthy)
roles/dhcpserver/tasks/main.yml:129

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/handlers/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/handlers/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/handlers/main.yml:9

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/tasks/main.yml:16

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/tasks/main.yml:18

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsclient/tasks/main.yml:19

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/handlers/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/handlers/main.yml:8

yaml: no new line character at the end of file (new-line-at-end-of-file)
roles/dnsserver/handlers/main.yml:9

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/handlers/main.yml:9

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/tasks/main.yml:152

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/tasks/main.yml:153

yaml: truthy value should be one of [false, true] (truthy)
roles/dnsserver/tasks/main.yml:154

yaml: truthy value should be one of [false, true] (truthy)
roles/noapparmor/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/noapparmor/tasks/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
roles/noapparmor/tasks/main.yml:9

yaml: truthy value should be one of [false, true] (truthy)
roles/noapparmor/tasks/main.yml:16

yaml: truthy value should be one of [false, true] (truthy)
roles/signs/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/signs/tasks/main.yml:26

yaml: truthy value should be one of [false, true] (truthy)
roles/signs/tasks/main.yml:64

yaml: truthy value should be one of [false, true] (truthy)
roles/signs/tasks/main.yml:65

yaml: truthy value should be one of [false, true] (truthy)
roles/techteam/tasks/users.yml:16

yaml: truthy value should be one of [false, true] (truthy)
roles/xymon/handlers/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/xymon/handlers/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
roles/xymon/handlers/main.yml:14

yaml: truthy value should be one of [false, true] (truthy)
roles/xymon/handlers/main.yml:15

yaml: too many spaces inside brackets (brackets)
roles/xymon/tasks/main.yml:5

yaml: truthy value should be one of [false, true] (truthy)
roles/zabbixagent/tasks/main.yml:7

yaml: truthy value should be one of [false, true] (truthy)
roles/zabbixagent/tasks/main.yml:21

yaml: truthy value should be one of [false, true] (truthy)
scale.yml:4

yaml: truthy value should be one of [false, true] (truthy)
scale.yml:12

yaml: truthy value should be one of [false, true] (truthy)
scale.yml:20

You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - yaml  # Violations reported by yamllint

Finished with 54 failure(s), 0 warning(s) on 20 files.
bash-5.1# pylint *.py
************* Module inventory
inventory.py:17:14: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
inventory.py:17:14: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
inventory.py:210:14: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
inventory.py:210:14: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
inventory.py:431:40: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)

-----------------------------------
Your code has been rated at 9.84/10

bash-5.1# pytest -vv
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /nix/store/ib89gapvyzncfyjpcwgwikz29jm1iy16-python3-3.10.2-env/bin/python3.10
cachedir: .pytest_cache
rootdir: /scale-network/ansible
plugins: flaky-3.7.0
collected 18 items                                                                                                                                                                                                                       

test_inventory.py::test_getfilelineshdr PASSED                                                                                                                                                                                     [  5%]
test_inventory.py::test_getfilelinesnobldg PASSED                                                                                                                                                                                  [ 11%]
test_inventory.py::test_getfilelinesbldg PASSED                                                                                                                                                                                    [ 16%]
test_inventory.py::test_dhcp6ranges PASSED                                                                                                                                                                                         [ 22%]
test_inventory.py::test_dhcp4ranges PASSED                                                                                                                                                                                         [ 27%]
test_inventory.py::test_makevlan PASSED                                                                                                                                                                                            [ 33%]
test_inventory.py::test_bitmasktonetmask PASSED                                                                                                                                                                                    [ 38%]
test_inventory.py::test_genvlans PASSED                                                                                                                                                                                            [ 44%]
test_inventory.py::test_ip4toptr PASSED                                                                                                                                                                                            [ 50%]
test_inventory.py::test_ip6toptr PASSED                                                                                                                                                                                            [ 55%]
test_inventory.py::test_isvalidip PASSED                                                                                                                                                                                           [ 61%]
test_inventory.py::test_roomalias PASSED                                                                                                                                                                                           [ 66%]
test_inventory.py::test_populatevlans PASSED                                                                                                                                                                                       [ 72%]
test_inventory.py::test_populateswitches PASSED                                                                                                                                                                                    [ 77%]
test_inventory.py::test_populaterouters PASSED                                                                                                                                                                                     [ 83%]
test_inventory.py::test_populateaps PASSED                                                                                                                                                                                         [ 88%]
test_inventory.py::test_populatepis PASSED                                                                                                                                                                                         [ 94%]
test_inventory.py::test_populateservers PASSED                                                                                                                                                                                     [100%]

=========================================================================================================== 18 passed in 0.15s ===========================================================================================================
bash-5.1# ./inventory.py | jq .
{
  "routers": {
    "hosts": [
      "br-mdf-01",
      "ex-mdf-01",
      "cf-mdf-01"
    ],
    "vars": {}
  },
  "servers": {
    "hosts": [
      "core1",
      "core2",
      "monitoring1",
      "automation1",
      "pkgcache"
    ],
    "vars": {}
  },
  "switches": {
    "hosts": [
      "Rm101-102",
      "NW-IDF",
(........... further output omitted .................)
```