### PR TITLE
[READY] - Init term-apply pkg and img

### DIFF
--- a/imgs/default.nix
+++ b/imgs/default.nix
@@ -12,4 +12,6 @@ rec {
   nwi-pr-utils = pkgs.callPackage ./nwi-pr-utils { };
 
   pki-validator = pkgs.callPackage ./pki-validator { };
+
+  term-apply = pkgs.callPackage ./term-apply { };
 }

--- a/imgs/term-apply/default.nix
+++ b/imgs/term-apply/default.nix
@@ -1,0 +1,35 @@
+{ system ? builtins.currentSystem, pkgs }:
+let
+  nwi = import ../../nwi.nix;
+  lib = pkgs.lib;
+  contents = with pkgs; [ awscli2 cacert coreutils bash term-apply minio-client ];
+in
+pkgs.dockerTools.buildImage {
+  inherit contents;
+  name = "nebulaworks/term-apply";
+  # Doesnt matter will use the derivation
+  # when publishing to registry
+  tag = "latest";
+  extraCommands = ''
+    # make sure /tmp exists
+    mkdir -m 1777 tmp
+    mkdir -p -m 1750 usr/local/term-apply/resumes
+    mkdir -p -m 1750 usr/local/term-apply/data
+  '';
+  config = {
+    Cmd = [ "/bin/term-apply" ];
+    Env = [
+      "PATH=/bin/"
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      "CLICOLOR_FORCE=1"
+      "TA_UPLOAD_DIR=/usr/local/term-apply/resumes"
+      "TA_DATAFILE=/usr/local/term-apply/data/applicants.csv"
+    ];
+    Labels = {
+      "com.nebulaworks.packages" = lib.strings.concatStringsSep "," (lib.lists.naturalSort (lib.lists.forEach contents (x: lib.strings.getName x + ":" + lib.strings.getVersion x)));
+      "org.opencontainers.image.authors" = nwi.company;
+      "org.opencontainers.image.source" = nwi.source;
+    };
+    WorkingDir = "/";
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -5,5 +5,6 @@ self: super:
   flasksample = super.callPackage ./pkgs/flasksample { };
   git-divergence = super.callPackage ./pkgs/git-divergence { };
   sshcb = super.callPackage ./pkgs/sshcb { };
+  term-apply = super.callPackage ./pkgs/term-apply { };
   terraform-config-inspect = super.callPackage ./pkgs/terraform-config-inspect { };
 }

--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+let
+  src = fetchFromGitHub {
+    owner = "nebulaworks";
+    rev = "5d3155c53e0c262560368b269530d74e858b3be9";
+    repo = "orion";
+    sha256 = "sha256:0sbawwivyl0z74v0qfi08q4ryky40w2jnlib73q83nhpzf7bj79l";
+  };
+
+in
+buildGoModule rec {
+  inherit src;
+  pname = "term-apply-unstable";
+  version = "2022-03-29";
+
+  sourceRoot = "${src.name}/apps/term-apply";
+
+  # Using old sha format since nix old
+  vendorSha256 = "166m30ccq6kcjmv3la4fkylzknyclqywh4pkfn4am9715231l495";
+  #vendorSha256 = "0hjk37kc5sdzhb9f232ljvnn19cd8f9slpay9ddb9ljggrm9gsak";
+
+  #"-X ${sourceRoot}/pkg/version.Commit=${src.rev}"
+  #"-X ${sourceRoot}/pkg/version.BuildTime=01011970"
+  # Having issues leveraging sourceroot will debug shortly
+  ldflags = [
+    "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.Commit=${src.rev}"
+    "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.BuildTime=01011970"
+  ];
+
+  meta = with lib; {
+    description = "SSH Daemon for resume applicants to nebulaworks";
+    homepage = "https://github.com/orion";
+    maintainers = "NWI";
+    license = licenses.bsd3;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@ with import ./pin { snapshot = "release-21.05_0"; };
 
 mkShell {
   buildInputs = [
+    nix
     bash
     jq
     skopeo


### PR DESCRIPTION
## Description of PR

Relates to: https://github.com/Nebulaworks/orion/pull/7

Init term-apply pkg and image to nix-garage for general usage: sshapply.nebulaworks.com

The process of applying is as simple as sshing and filling out the form presented via your ssh session:
```
ssh <github_user>@sshapply.nebulaworks.com
```

`scp` your resume to the server as well:

```
scp -P 23234 <resume>.pdf <github_user>@sshapply.nebulaworks.com:resume.pdf
```
> Note: your ssh key needs to be associated with the same github_user your are passing


## New Behavior
- term-apply available via nixpkg overlay and img artifact

## Tests
- Unit tests running for `term-apply`
- `publish` builds and pushed to dockerhub: https://github.com/Nebulaworks/nix-garage/actions/runs/2080355450
- CA cert bundlers included in container after:

```
Of course I need to include the CA bundles                                                                                                                                                                          
                                                                                                                                                                                                                    
Was getting the following in the log when checking github for                                                                                                                                                       
fingerprints:                                                                                                                                                                                                       
                                                                                                                                                                                                                    
2022/03/31 16:21:23 Get "https://github.com/sarcasticadmin.keys": x509:                                                                                                                                             
certificate signed by unknown authority                                                                                                                                                                             
2022/03/31 16:21:23 Get "https://github.com/sarcasticadmin.keys": x509:                                                                                                                                             
certificate signed by unknown authority                                                                                                                                                                             
2022/03/31 16:21:23 Get "https://github.com/sarcasticadmin.keys": x509:                                                                                                                                             
certificate signed by unknown authority
```
- Builds working as intended:

`nix-build -A pkgs.term-apply`:

```
...
Building subPackage ./pkg/ui                                                                                                                                                                                        
running tests                                                                                                                                                                                                       
=== RUN   TestIsValidEmail                                                                                                                                                                                          
--- PASS: TestIsValidEmail (0.00s)                                                                                                                                                                                  
=== RUN   TestIsValidRole                                                                                                                                                                                           
--- PASS: TestIsValidRole (0.00s)                                                                                                                                                                                   
PASS                                                                                                                                                                                                                
ok      github.com/nebulaworks/orion/apps/term-apply/pkg/applicant      0.002s                                                                                                                                      
installing                                                                                                
post-installation fixup                                                                                                                                                                                             
shrinking RPATHs of ELF executables and libraries in /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29                          
shrinking /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29/bin/term-apply                                                                                                                 
strip is /nix/store/pja9g36cy32z3d51942jqk91a6l2d5nv-gcc-wrapper-10.3.0/bin/strip                                                                                                                                   
stripping (with command strip and flags -S) in /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29/bin                                                                                       
patching script interpreter paths in /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29                                                                                                     
checking for references to /build/ in /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29...                                                                                                 
/nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29
```

`nix-build -A imgs.term-apply`

```                                                       
these 3 derivations will be built:      
  /nix/store/hmnl183f2a3hamb4mybxzc9jz9cqpmk6-docker-layer-term-apply.drv
  /nix/store/an55s77k042q53d28l2bl5aij847c06b-runtime-deps.drv                                            
  /nix/store/j2mjg2j20sp91b83vnn5yv6cjzzxi3xw-docker-image-term-apply.tar.gz.drv
building '/nix/store/hmnl183f2a3hamb4mybxzc9jz9cqpmk6-docker-layer-term-apply.drv'...
Adding contents...                              
Adding /nix/store/dj89pwrdlycn8iyn08v8znmynjz1zsi9-coreutils-9.0
Adding /nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
Adding /nix/store/rh20w1g3hdszm5k2wan6lg5p1wy085wm-term-apply-unstable-2022-03-29
Packing layer...                                                                                          
Finished building layer 'term-apply'                 
building '/nix/store/an55s77k042q53d28l2bl5aij847c06b-runtime-deps.drv'...                                
building '/nix/store/j2mjg2j20sp91b83vnn5yv6cjzzxi3xw-docker-image-term-apply.tar.gz.drv'...
Adding layer...                                                                                           
tar: Removing leading `/' from member names                                                               
Adding meta...                      
Cooking the image...                                                                                      
Finished.                                            
/nix/store/shhmfpym4zaa66sq40alkcrgl4kxs6ad-docker-image-term-apply.tar.gz
```

Container starting in local docker environment:

```
$ docker-run nebulaworks/term-apply:latest
sh-5.1# term-apply
2022/03/31 16:11:34 
Build Info:
===========
commit:      6214c9827ccac5e7b80640c9e5786f1093288623
build time:  01011970

2022/03/31 16:11:34 TA_HOST not found, defaulting to '0.0.0.0'
2022/03/31 16:11:34 bad ports string  or TA_PORT not found, defaulting to 23234
2022/03/31 16:11:34 Importing existing resumes from /usr/local/term-apply/resumes
2022/03/31 16:11:34 Starting SSH server on 0.0.0.0:23234
```

Pulling from a dockerhub:

```
$ docker-run nebulaworks/term-apply:589ykblva4s7mycz50bwfmxkhzg1i2j8
Unable to find image 'nebulaworks/term-apply:589ykblva4s7mycz50bwfmxkhzg1i2j8' locally
589ykblva4s7mycz50bwfmxkhzg1i2j8: Pulling from nebulaworks/term-apply
37a18d0ca35e: Pull complete 
Digest: sha256:58ae61d3aae9f51fba8409d7af81145313d435415ff3f2f3a8f480df3be0ada4
Status: Downloaded newer image for nebulaworks/term-apply:589ykblva4s7mycz50bwfmxkhzg1i2j8
sh-4.4# term-apply
2022/04/02 00:13:54 
Build Info:
===========
commit:      5d3155c53e0c262560368b269530d74e858b3be9
build time:  01011970

2022/04/02 00:13:54 TA_HOST not found, defaulting to '0.0.0.0'
2022/04/02 00:13:54 bad ports string  or TA_PORT not found, defaulting to 23234
2022/04/02 00:13:54 Importing existing resumes from /usr/local/term-apply/resumes
2022/04/02 00:13:54 Starting SSH server on 0.0.0.0:23234
```