### PR TITLE
[READY] - Fixing daily img build and update pinning

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,10 +9,9 @@ jobs:
   upstream_nixpkgs:
     name: 'Build images off master'
     runs-on: ubuntu-18.04
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
-
+      image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
     steps:
       - name: 'Checkout'
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,7 +14,8 @@ jobs:
       image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        # actions checkout v1
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ env.BRANCH }} # should always be master but might be something else if testing
       - name: 'Publish off latest nixpkgs master'

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Verify Nix Configs
         id: format
         run: |
+          nix-shell --run '\
           cd $GITHUB_WORKSPACE
           has_failed="false"
           for file_path in $(find . -name "*.nix"); do
             fmt_file_path="${file_path%.*}_fmt.nix"
-            nix-shell --run "cat $file_path | nixpkgs-fmt > $fmt_file_path" 
+            cat $file_path | nixpkgs-fmt > $fmt_file_path
 
             set +e
             differences=$(diff $file_path $fmt_file_path)
@@ -53,5 +54,5 @@ jobs:
           if [ "$has_failed" == "true" ]; then
             echo "::error ::Some nix configs were not properly formatted beforehand with nixpkgs-fmt."
             exit 1
-          fi
+          fi'
         continue-on-error: false

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -13,9 +13,9 @@ jobs:
     name: Run nixpkgs-fmt
     runs-on: ubuntu-18.04
 
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
+      image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
 
     steps:
         # Checks out repository to docker container

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
         # Checks out repository to docker container
         # Utilizes the commit from the open PR
-        # Using SHA v2
+        # Using actions v1
       - name: Pulls Repository
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -67,9 +67,9 @@ jobs:
     outputs:
       allImgs: ${{ steps.publish.outputs.allImgs }}
 
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
+           image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
 
     steps:
       # Checks out repository to docker container

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -74,9 +74,9 @@ jobs:
     steps:
       # Checks out repository to docker container
       # Utilizes the commit from the open PR, which was gotten from the previous step
-      # Using SHA v2
+      # Using actions checkout v1
       - name: Pulls repository code
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ needs.verify.outputs.sha }}
 

--- a/pin/default.nix
+++ b/pin/default.nix
@@ -5,7 +5,7 @@ let
   nixpkgs = builtins.fromJSON (builtins.readFile (./pins + "/${snapshot}.json"));
   src = bootstrap.fetchFromGitHub {
     owner = "NixOS";
-    repo = "nixpkgs-channels";
+    repo = "nixpkgs";
     inherit (nixpkgs) rev sha256;
   };
 in

--- a/pin/pins/master_0.json
+++ b/pin/pins/master_0.json
@@ -1,8 +1,8 @@
 {
   "url": "https://github.com/NixOS/nixpkgs.git",
-  "rev": "3ef1d2a9602c18f8742e1fb63d5ae9867092e3d6",
-  "date": "2021-10-20T15:05:21Z",
-  "sha256": "0yicccl89rfa5nk4ic46ydihvzsw1phzsypnlzmzrdnwsxi3r9d4",
+  "rev": "a1f99456162616d3cf89563e58e99244e271cb13",
+  "date": "2022-04-01T14:55:48Z",
+  "sha256": "1h0bi1fvkqzmmdzk0khmmihik2pm582qvb4b7bxa4sygq8hdl7hp",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -16,9 +16,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/apps/term-apply";
 
-  # Using old sha format since nix old
-  vendorSha256 = "166m30ccq6kcjmv3la4fkylzknyclqywh4pkfn4am9715231l495";
-  #vendorSha256 = "0hjk37kc5sdzhb9f232ljvnn19cd8f9slpay9ddb9ljggrm9gsak";
+  vendorSha256 = "sha256-U+mXan5P0rRaS15dqpNDjaVg7ZZUDOHSgr/pwuYZU0I=";
 
   #"-X ${sourceRoot}/pkg/version.Commit=${src.rev}"
   #"-X ${sourceRoot}/pkg/version.BuildTime=01011970"

--- a/publish-imgs
+++ b/publish-imgs
@@ -56,7 +56,7 @@ attr=${1:-'imgs'}
 BUILT=()
 
 for entry in $(nix-instantiate --eval --strict --json -A $attr $nixtop | jq -r 'keys[]' ); do
-  derivation=$(nix show-derivation -f $nixtop $attr.$entry)
+  derivation=$(nix --extra-experimental-features "nix-command flakes" show-derivation -f $nixtop $attr.$entry)
   image_fullname=$(echo $derivation | jq -r '.[] | .env.imageName')
   org=$(echo $image_fullname | cut -d '/' -f 1)
   image_name=$(echo $image_fullname | cut -d '/' -f 2)

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import ./pin { snapshot = "release-21.05_0"; };
+with import ./pin { snapshot = "master_0"; };
 
 mkShell {
   buildInputs = [


### PR DESCRIPTION
## Description of PR

Daily container build thats checking nixpkgs upstream is failing: https://github.com/Nebulaworks/nix-garage/actions/runs/2116049726

## Previous Behavior
- We were referencing older pins from 2021 nixpkgs
- v2 actions checkout

## New Behavior
- Leverage a pin `nix-shell` tools calling in CI workflow during img build
- Fix reference from pin to point to n`ixpkgs` instead of deprecated `nix-channels`
- switching to v1 actions checkout since it doesnt depend on javascript and `/etc/os_release` (open issue from 2020): https://github.com/actions/checkout/issues/334
- Move the linting action to encompass entire `nix-shell` vs only oneliner 

## Tests
- Running `nix-build` locally with updates passes as expected
- Triggered the daily dispatch: https://github.com/Nebulaworks/nix-garage/actions/runs/2174432446 but cant actually run the publish workflow so we cant test this until the pipeline is merged to `master`
