### PR TITLE
[READY] - Updating the existing nix container refs and workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,10 +9,9 @@ jobs:
   upstream_nixpkgs:
     name: 'Build images off master'
     runs-on: ubuntu-18.04
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
-
+      image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
     steps:
       - name: 'Checkout'
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,7 +14,8 @@ jobs:
       image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        # actions checkout v1
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ env.BRANCH }} # should always be master but might be something else if testing
       - name: 'Publish off latest nixpkgs master'

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Verify Nix Configs
         id: format
         run: |
+          nix-shell --run '\
           cd $GITHUB_WORKSPACE
           has_failed="false"
           for file_path in $(find . -name "*.nix"); do
             fmt_file_path="${file_path%.*}_fmt.nix"
-            nix-shell --run "cat $file_path | nixpkgs-fmt > $fmt_file_path" 
+            cat $file_path | nixpkgs-fmt > $fmt_file_path
 
             set +e
             differences=$(diff $file_path $fmt_file_path)
@@ -53,5 +54,5 @@ jobs:
           if [ "$has_failed" == "true" ]; then
             echo "::error ::Some nix configs were not properly formatted beforehand with nixpkgs-fmt."
             exit 1
-          fi
+          fi'
         continue-on-error: false

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -13,9 +13,9 @@ jobs:
     name: Run nixpkgs-fmt
     runs-on: ubuntu-18.04
 
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
+      image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
 
     steps:
         # Checks out repository to docker container

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
         # Checks out repository to docker container
         # Utilizes the commit from the open PR
-        # Using SHA v2
+        # Using actions v1
       - name: Pulls Repository
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -67,9 +67,9 @@ jobs:
     outputs:
       allImgs: ${{ steps.publish.outputs.allImgs }}
 
-    # Utilizing nixos/nix docker image v2.3.12
+    # Utilizing nixos/nix docker image v2.7.0
     container:
-      image: nixos/nix@sha256:d9bb3b85b846eb0b6c5204e0d76639dff72c7871fb68f5d4edcfbb727f8a5653
+           image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce
 
     steps:
       # Checks out repository to docker container

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -74,9 +74,9 @@ jobs:
     steps:
       # Checks out repository to docker container
       # Utilizes the commit from the open PR, which was gotten from the previous step
-      # Using SHA v2
+      # Using actions checkout v1
       - name: Pulls repository code
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        uses: actions/checkout@0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc
         with:
           ref: ${{ needs.verify.outputs.sha }}
 


### PR DESCRIPTION
## Description of PR

Unfortunately I dont have a good way to set this without it for landing in `master` Im still waiting on some standardizing: https://github.com/Nebulaworks/action-standardize-pr-comment :slightly_smiling_face: 

But regardless the go here is pretty straightforward for using newer containers with nix on them compared to the existing 2.3.12 version. This is to support a related PR: https://github.com/Nebulaworks/nix-garage/pull/51

## Previous Behavior
- Using nix 2.3.12 containers in workflows
- workflows using v2 checkout vs v1
- nix-shell was being used for part of the workflow for linting instead of the entire script

## New Behavior
- nix container 2.7.0
- workflows using v1 for checkout
- nix-shell for entire diff of nixpkgs-fmt 

## Tests
- How was this PR tested?
