### PR TITLE
[READY] - Updates for offline yubikey iso build

### DIFF
--- a/isos/yubikey/default.nix
+++ b/isos/yubikey/default.nix
@@ -17,7 +17,6 @@ with pkgs; {
     # Pre-req Packages
     gnupg
     pinentry-curses
-    pinentry-qt
     paperkey
     wget
     pcsctools
@@ -50,7 +49,7 @@ with pkgs; {
   services.pcscd.enable = true;
 
   # Sets the root user to have an empty password
-  services.mingetty.helpLine = "The 'root' account has an empty password.";
+  services.getty.helpLine = "The 'root' account has an empty password.";
   users.extraUsers.root.initialHashedPassword = "";
 
   # Makes sure that all data is written to ram and not persistently stored

--- a/isos/yubikey/default.nix
+++ b/isos/yubikey/default.nix
@@ -2,8 +2,10 @@
 # To build the iso: 
 # nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=default.nix --out-link installer
 
-{ config, pkgs, ... }:
-
+{ config, ... }:
+let
+  pkgs = import ../../pin { snapshot = "master_0"; };
+in
 with pkgs; {
   # Utilizing the bare minimum version in this case. Can also use the graphical version as well
   # Also adds in the specific nix-channel that was used to build the iso into the iso, just in case if ad-hoc packages are needed.


### PR DESCRIPTION
## Description of PR

Fixes: #62 

## Previous Behavior
- Yubikey iso build was reference config and extra nixpkgs
- No pin for nixpkgs

## New Behavior
- Removed uneeded nixpkg
- Updated config for the newer version of nixpkgs
- Pinning to nixpkgs to make it reproducible

## Tests
- Locally was able to build:

```
$ cd isos/yubikey/
$ nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=default.nix --out-link installer                                                       
these 59 derivations will be built:                                                                                                                                                                                 
  /nix/store/0rwkp1iflf0ignr1zrl1w49hyx61fi0n-kernel-modules.drv                                                                                                                                                    
  /nix/store/1fz0f0h7746pfxbma37ss3m19hjbs27b-users-groups.json.drv                                                                                                                                                 
  /nix/store/n7z0bh2yxiwq5l467lxk8m00f4in2rnh-firmware.drv 
Number of ids (unique uids + gids) 1                                                                      
Number of uids 1   
        root (0)    
Number of gids 1            
        root (0)    
building '/nix/store/ddpb2h6zb7972ks54cb9gr6jkjq11dpi-nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso.drv'...
GNU xorriso 1.5.4.pl02 : RockRidge filesystem manipulator, libburnia project.
                                                     
xorriso : NOTE : Environment variable SOURCE_DATE_EPOCH encountered with value 315532800
Drive current: -outdev 'stdio:/nix/store/gviclfhqgxa4kjpfqlnh57qk6q5bj7xg-nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso/iso/nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso'
Media current: stdio file, overwriteable
Media status : is blank
Media summary: 0 sessions, 0 data blocks, 0 data,  321g free
xorriso : WARNING : -volid text does not comply to ISO 9660 / ECMA 119 rules
xorriso : UPDATE :     241 files added in 1 seconds
Added 13 items from file 'pathlist'
xorriso : UPDATE :     241 files added in 1 seconds                                                       
xorriso : NOTE : Copying to System Area: 432 bytes from file '/nix/store/xgyy7lljls358l8j87mbjc6xvf0v1s0g-syslinux-unstable-20190207/share/syslinux/isohdpfx.bin'
libisofs: NOTE : Aligned image size to cylinder size by 499 blocks        
xorriso : UPDATE :  5.13% done
xorriso : UPDATE :  52.20% done                                                                           
ISO image produced: 443392 sectors                   
Written to medium : 443392 sectors at LBA 0                                                                                                                                                                         
Writing to 'stdio:/nix/store/gviclfhqgxa4kjpfqlnh57qk6q5bj7xg-nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso/iso/nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso' completed successfully.
                                                     
/nix/store/gviclfhqgxa4kjpfqlnh57qk6q5bj7xg-nixos-22.05pre363562.30d3d79b7d3-x86_64-linux.iso  
```