### PR TITLE
[READY] - [issue-511] - bump term-apply pkg for s3 resume/csv support

### DIFF
--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -3,9 +3,9 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "5d3155c53e0c262560368b269530d74e858b3be9";
+    rev = "3a1aca5aa9a31815d915c145010a7432f41c10aa";
     repo = "orion";
-    sha256 = "sha256:0sbawwivyl0z74v0qfi08q4ryky40w2jnlib73q83nhpzf7bj79l";
+    sha256 = "sha256:1a1ympq4654rx46s45pwn0dxdn6mbj1nqv1f7n6h72jszi09y34g";
   };
 
 in
@@ -16,11 +16,8 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/apps/term-apply";
 
-  vendorSha256 = "sha256-U+mXan5P0rRaS15dqpNDjaVg7ZZUDOHSgr/pwuYZU0I=";
+  vendorSha256 = "sha256-DA923aOtIvvzre6PFUwrnHwb0WMe67v3eqp0Ejm1ArI=";
 
-  #"-X ${sourceRoot}/pkg/version.Commit=${src.rev}"
-  #"-X ${sourceRoot}/pkg/version.BuildTime=01011970"
-  # Having issues leveraging sourceroot will debug shortly
   ldflags = [
     "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.Commit=${src.rev}"
     "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.BuildTime=01011970"


### PR DESCRIPTION
## Description of PR
Bumps version of term-apply to target version referenced in https://github.com/Nebulaworks/orion/pull/11 (technically it targets the branch directly on origin with the same name given we shouldn't use forks for this)

## Previous Behavior
term-apply pkg referenced previous version which lacked s3 support

## New Behavior
term-apply pkg references new version with s3 support

## Tests
- [x] this nix build was tested locally using `nix-build -A pkgs.term-apply` followed by `nix-build -A imgs.term-apply`, then loading it into docker and running. Confirmed it's the expected new version
- [ ] publish (once published then we can open ANOTHER PR in infra with the new image this spits out, then deploy to dev, then validate, then go back and merge the [Orion PR](https://github.com/Nebulaworks/orion/pull/11) then update this PR to reflect Orion's new master, then publish here again, then update infra to relect the new image, then merge this, then do an infra release)
