### PR TITLE
[READY] - [issue-58] - switch sshcb to build using ldflags

### DIFF
--- a/pkgs/sshcb/default.nix
+++ b/pkgs/sshcb/default.nix
@@ -14,8 +14,7 @@ buildGoModule rec {
 
   vendorSha256 = "1zgf7fczm0nx7x6lqjjxy0gkd53amszjjyc9ldy4rzf7y8n15ry1";
 
-  buildFlagsArray = [
-    "-ldflags="
+  ldflags = [
     "-s"
     "-w"
     "-X github.com/${owner}/${pname}/cmd.Version=${rev}"


### PR DESCRIPTION
Fixes #58 

## Description of PR
sshcb build now leverages `ldflags` instead of deprecated `buildFlagsArray`.

## Previous Behavior
sshcb build leveraged `buildFlagsArray`

## New Behavior
sshcb build now leverages `ldflags`

## Tests
- [x] local build and test executable
```
$ nix-build -A pkgs.sshcb
these 3 derivations will be built:
  /nix/store/mfnp16nh5sajz4xswcd66dgz8xa3nl9l-source.drv
  /nix/store/2s1nwk047araj5xcg2z54bh1x5c2b7lm-sshcb-0.2.1-go-modules.drv
  /nix/store/851k4vgwspqfjggwwrhklw5r69f441hp-sshcb-0.2.1.drv
building '/nix/store/mfnp16nh5sajz4xswcd66dgz8xa3nl9l-source.drv'...

trying https://github.com/sarcasticadmin/sshcb/archive/v0.2.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  8377    0  8377    0     0  14778      0 --:--:-- --:--:-- --:--:--  122k
unpacking source archive /build/v0.2.1.tar.gz
building '/nix/store/2s1nwk047araj5xcg2z54bh1x5c2b7lm-sshcb-0.2.1-go-modules.drv'...
unpacking sources
unpacking source archive /nix/store/lxkra2c1y8iqbh0qxsyvh3hil5l3pn3l-source
source root is source
patching sources
configuring
building
go: downloading github.com/mattn/go-isatty v0.0.10
go: downloading github.com/aws/aws-sdk-go v1.25.16
go: downloading github.com/spf13/cobra v0.0.5
go: downloading golang.org/x/sys v0.0.0-20191008105621-543471e840be
go: downloading github.com/spf13/pflag v1.0.3
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
installing
building '/nix/store/851k4vgwspqfjggwwrhklw5r69f441hp-sshcb-0.2.1.drv'...
unpacking sources
unpacking source archive /nix/store/lxkra2c1y8iqbh0qxsyvh3hil5l3pn3l-source
source root is source
patching sources
configuring
building
Building subPackage .
encoding
internal/unsafeheader
internal/itoa
unicode
internal/goexperiment
internal/abi
internal/cpu
unicode/utf16
math/bits
runtime/internal/sys
runtime/internal/atomic
unicode/utf8
internal/race
container/list
sync/atomic
crypto/internal/subtle
crypto/subtle
vendor/golang.org/x/crypto/cryptobyte/asn1
github.com/aws/aws-sdk-go/aws/client/metadata
internal/nettrace
vendor/golang.org/x/crypto/internal/subtle
runtime/internal/math
internal/bytealg
math
runtime
github.com/aws/aws-sdk-go/internal/sdkmath
internal/reflectlite
sync
internal/singleflight
internal/testlog
math/rand
runtime/cgo
errors
sort
internal/oserror
io
path
strconv
vendor/golang.org/x/net/dns/dnsmessage
crypto/elliptic/internal/fiat
syscall
github.com/aws/aws-sdk-go/internal/sdkio
bytes
hash
crypto/internal/randutil
strings
crypto/hmac
hash/crc32
vendor/golang.org/x/crypto/hkdf
crypto/rc4
crypto
reflect
vendor/golang.org/x/text/transform
github.com/aws/aws-sdk-go/internal/sdkuri
bufio
regexp/syntax
net/http/internal/ascii
internal/syscall/execenv
time
internal/syscall/unix
regexp
github.com/aws/aws-sdk-go/internal/sdkrand
context
io/fs
internal/poll
os
internal/fmtsort
encoding/binary
encoding/base64
vendor/golang.org/x/crypto/poly1305
crypto/sha512
crypto/md5
crypto/sha1
crypto/sha256
crypto/cipher
crypto/ed25519/internal/edwards25519/field
golang.org/x/sys/unix
io/ioutil
path/filepath
fmt
encoding/pem
crypto/ed25519/internal/edwards25519
vendor/golang.org/x/sys/cpu
crypto/des
vendor/golang.org/x/crypto/chacha20
crypto/aes
github.com/aws/aws-sdk-go/internal/shareddefaults
os/exec
vendor/golang.org/x/crypto/chacha20poly1305
log
net/url
vendor/golang.org/x/crypto/curve25519
encoding/json
vendor/golang.org/x/net/http2/hpack
encoding/hex
net/http/internal
mime/quotedprintable
compress/flate
mime
encoding/xml
encoding/csv
math/big
vendor/golang.org/x/text/unicode/norm
net
github.com/aws/aws-sdk-go/aws/awserr
vendor/golang.org/x/text/unicode/bidi
flag
text/template/parse
github.com/aws/aws-sdk-go/internal/ini
github.com/mattn/go-isatty
github.com/sarcasticadmin/sshcb/logs
compress/gzip
vendor/golang.org/x/text/secure/bidirule
vendor/golang.org/x/net/idna
github.com/jmespath/go-jmespath
github.com/aws/aws-sdk-go/aws/endpoints
github.com/aws/aws-sdk-go/aws/credentials
text/template
github.com/aws/aws-sdk-go/aws/credentials/processcreds
crypto/rand
crypto/dsa
encoding/asn1
crypto/elliptic
github.com/aws/aws-sdk-go/aws/awsutil
crypto/ed25519
crypto/rsa
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
github.com/spf13/pflag
net/textproto
vendor/golang.org/x/net/http/httpproxy
crypto/x509
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/tls
github.com/spf13/cobra
net/http/httptrace
net/http
github.com/aws/aws-sdk-go/aws
net/http/httputil
github.com/aws/aws-sdk-go/aws/request
github.com/aws/aws-sdk-go/aws/csm
github.com/aws/aws-sdk-go/aws/corehandlers
github.com/aws/aws-sdk-go/aws/client
github.com/aws/aws-sdk-go/private/protocol
github.com/aws/aws-sdk-go/private/protocol/rest
github.com/aws/aws-sdk-go/private/protocol/query/queryutil
github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
github.com/aws/aws-sdk-go/aws/ec2metadata
github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
github.com/aws/aws-sdk-go/private/protocol/ec2query
github.com/aws/aws-sdk-go/private/protocol/query
github.com/aws/aws-sdk-go/aws/signer/v4
github.com/aws/aws-sdk-go/aws/defaults
github.com/aws/aws-sdk-go/service/sts
github.com/aws/aws-sdk-go/service/ec2
github.com/aws/aws-sdk-go/service/sts/stsiface
github.com/aws/aws-sdk-go/aws/credentials/stscreds
github.com/aws/aws-sdk-go/aws/session
github.com/sarcasticadmin/sshcb/builder
github.com/sarcasticadmin/sshcb/cmd
github.com/sarcasticadmin/sshcb
Building subPackage ./builder
Building subPackage ./cmd
Building subPackage ./logs
running tests
=== RUN   TestIncrementID
--- PASS: TestIncrementID (0.00s)
=== RUN   TestIncrementID2
--- PASS: TestIncrementID2 (0.00s)
PASS
ok      github.com/sarcasticadmin/sshcb/builder 0.003s
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1
shrinking /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1/bin/sshcb
strip is /nix/store/pja9g36cy32z3d51942jqk91a6l2d5nv-gcc-wrapper-10.3.0/bin/strip
stripping (with command strip and flags -S) in /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1/bin 
patching script interpreter paths in /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1
checking for references to /build/ in /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1...
/nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1
```
- [x] verify `ldflags` args still work by validating version
```
$ /nix/store/wrn2wz677gkxjg1kg40x2d3gd0dw36az-sshcb-0.2.1/bin/sshcb version
v0.2.1
```