### PR TITLE
[READY] - [issue 522] - term-apply 2022-05-13 release

### DIFF
--- a/imgs/term-apply/README.md
+++ b/imgs/term-apply/README.md
@@ -1,0 +1,7 @@
+# term-apply
+SSH Daemon for resume applicants to Nebulaworks.
+
+The latest term-apply documentation can be found in the Nebulaworks [Orion](https://github.com/Nebulaworks/orion/tree/main/apps/term-apply) Github repo.
+
+---------------
+Originated from Nebulaworks's [nix-garage](https://github.com/Nebulaworks/nix-garage) CI.

--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -3,16 +3,16 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "3a1aca5aa9a31815d915c145010a7432f41c10aa";
+    rev = "fb0b1491c68afca0e06703835f984b371e0571e6";
     repo = "orion";
-    sha256 = "sha256:1a1ympq4654rx46s45pwn0dxdn6mbj1nqv1f7n6h72jszi09y34g";
+    sha256 = "sha256:12fv5ck0zv21f2q6qqlag1hdwr2dqblj9c02mnvwxscqrya907nj";
   };
 
 in
 buildGoModule rec {
   inherit src;
   pname = "term-apply-unstable";
-  version = "2022-03-29";
+  version = "2022-05-13";
 
   sourceRoot = "${src.name}/apps/term-apply";
 
@@ -24,7 +24,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "SSH Daemon for resume applicants to nebulaworks";
+    description = "SSH Daemon for resume applicants to Nebulaworks";
     homepage = "https://github.com/orion";
     maintainers = "NWI";
     license = licenses.bsd3;


### PR DESCRIPTION
## Description of PR
2022-05-13 release of term-apply

## New Behavior
- log resume uploads past the first in term-apply -  [[o13](https://github.com/Nebulaworks/orion/pull/13)]
- environment variable parsing all handled in one place when creating new config [[o15](https://github.com/Nebulaworks/orion/pull/15)]
- s3 prefixes can be changed with environment variables - [[o15](https://github.com/Nebulaworks/orion/pull/15)]
- add README to term-apply [[o16](https://github.com/Nebulaworks/orion/pull/16)]


## Tests
- [x] locally built and tested nix term-apply pkg
```
$ TA_UPLOAD_DIR=/tmp/uploads TA_BUCKET=test-bucket /nix/store/1yc3pzhjf3zfzmz1z07k1i645v36scyv-term-apply-unstable-2022-05-13/bin/term-apply 
2022/05/13 15:42:44 
Build Info:
===========
commit:      fb0b1491c68afca0e06703835f984b371e0571e6
build time:  01011970

2022/05/13 15:42:44 TA_HOST set to '0.0.0.0'
2022/05/13 15:42:44 TA_PORT set to '23234'
2022/05/13 15:42:44 TA_UPLOAD_DIR set to '/tmp/uploads'
2022/05/13 15:42:44 TA_DATAFILE set to 'applicants.csv'
2022/05/13 15:42:44 TA_BUCKET set to 'test-bucket'
2022/05/13 15:42:44 TA_CSV_PREFIX set to '/term-apply/dev/data'
2022/05/13 15:42:44 TA_RESUME_PREFIX set to '/term-apply/dev/resumes'
2022/05/13 15:42:44 Starting SSH server on 0.0.0.0:23234
```
- [x] locally built and tested nix term-apply img
```
$ docker load < /nix/store/w4vfvzbg9vikczwv17ln2f5giirs4ajs-docker-image-term-apply.tar.gz
4f6efd1d3287: Loading layer  467.4MB/467.4MB
Loaded image: nebulaworks/term-apply:latest

$ docker run -e TA_BUCKET=test-bucket -ti nebulaworks/term-apply:latest 
2022/05/13 22:46:54 
Build Info:
===========
commit:      fb0b1491c68afca0e06703835f984b371e0571e6
build time:  01011970

2022/05/13 22:46:54 TA_HOST set to '0.0.0.0'
2022/05/13 22:46:54 TA_PORT set to '23234'
2022/05/13 22:46:54 TA_UPLOAD_DIR set to '/usr/local/term-apply/resumes'
2022/05/13 22:46:54 TA_DATAFILE set to '/usr/local/term-apply/data/applicants.csv'
2022/05/13 22:46:54 TA_BUCKET set to 'test-bucket'
2022/05/13 22:46:54 TA_CSV_PREFIX set to '/term-apply/dev/data'
2022/05/13 22:46:54 TA_RESUME_PREFIX set to '/term-apply/dev/resumes'
2022/05/13 22:46:54 Starting SSH server on 0.0.0.0:23234
```
- [ ] publish in PR
- [ ] verify published image on Docker Hub
