### PR TITLE
[READY] - [issue-69] - Omit checks for magic-wormhole-relay temporarily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,6 +34,7 @@ jobs:
 
           # Beware of quoting here
           sha=$(nix-shell --run "curl --request GET --url 'https://api.github.com/repos/nixos/nixpkgs/commits?per_page=1' -H 'Accept: application/vnd.github.v3+json' | jq -r '.[0].sha'")
+          echo "Utilizing sha: ${sha}"
           export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/${sha}.tar.gz
           # No need to create docker repos since we can assume they exist
           # just publish here

--- a/imgs/magic-wormhole-mailbox/default.nix
+++ b/imgs/magic-wormhole-mailbox/default.nix
@@ -2,8 +2,15 @@
 let
   nwi = import ../../nwi.nix;
   lib = pkgs.lib;
-  importedPythonPkgs = with pkgs; python3.withPackages (pythonPkgs: with pythonPkgs; [ magic-wormhole-mailbox-server ]);
-  contents = with pkgs; [ bash coreutils procps importedPythonPkgs ];
+
+  # Temporarily disable python checks
+  # TODO: Watching for upstream fix: https://github.com/NixOS/nixpkgs/issues/164775
+  dontCheckPython = drv: drv.overridePythonAttrs (old: { doCheck = false; });
+  # Keep python3 instead of specific python version for flexibility based on nixpkgs pin
+  pythonEnv = pkgs.python3.withPackages (ps: [
+    (dontCheckPython ps.magic-wormhole-mailbox-server)
+  ]);
+  contents = with pkgs; [ bash coreutils procps pythonEnv ];
 in
 pkgs.dockerTools.buildImage {
   inherit contents;


### PR DESCRIPTION
## Description of PR

Relates to:  https://github.com/NixOS/nixpkgs/issues/164775

There is an existing issues around daily build, see: https://github.com/Nebulaworks/nix-garage/actions/runs/2385446134

## Previous Behavior
- Daily builds against nixpkgs `master` are failing due to twisted `dropin.cache` conflicts

## New Behavior
- Disable twisted test until upstream `twisted` issues with `dropin.cache`

## Tests
- Triggering a dispatch of the `daily workflow` works as expected: https://github.com/Nebulaworks/nix-garage/runs/6597588623
- Able to trigger a workflow via `publish` command: https://github.com/Nebulaworks/nix-garage/actions/runs/2399294622
- Able to build and run wormhole img successfully.

Against existing `pin` (https://github.com/Nebulaworks/nix-garage/actions/runs/2399294622):

```
$ docker run -it --rm nebulaworks/magic-wormhole-mailbox:afm6v1gw9rk0ihga76gcpvkjcy8y3qk5
Unable to find image 'nebulaworks/magic-wormhole-mailbox:afm6v1gw9rk0ihga76gcpvkjcy8y3qk5' locally
afm6v1gw9rk0ihga76gcpvkjcy8y3qk5: Pulling from nebulaworks/magic-wormhole-mailbox
c4c3a3802cf2: Pull complete 
Digest: sha256:b346ac86255d48d929143316ddf26815219880e6d7e512cc7e9180663d6eee61
Status: Downloaded newer image for nebulaworks/magic-wormhole-mailbox:afm6v1gw9rk0ihga76gcpvkjcy8y3qk5
2022-05-27T23:59:44+0000 [-] RLIMIT_NOFILE.soft was 1048576, leaving it alone
2022-05-27T23:59:44+0000 [-] populating new database with schema channel v1
2022-05-27T23:59:44+0000 [-] populating new database with schema usage v2
2022-05-27T23:59:44+0000 [-] not blurring access times
2022-05-27T23:59:44+0000 [-] websocket listening on ws://HOSTNAME:PORT/v1
2022-05-27T23:59:44+0000 [-] Wormhole relay server running
2022-05-27T23:59:44+0000 [-] not blurring access times
2022-05-27T23:59:44+0000 [-] beginning app prune
2022-05-27T23:59:44+0000 [-] app prune ends, 0 apps
2022-05-27T23:59:44+0000 [-] PrivacyEnhancedSite starting on 4000
2022-05-27T23:59:44+0000 [wormhole_mailbox_server.web.PrivacyEnhancedSite#info] Starting factory <wormhole_mailbox_server.web.PrivacyEnhancedSite object at 0x7f898ba1db50>
2022-05-27T23:59:44+0000 [twisted.application.runner._runner.Runner#info] Starting reactor...
```

against upstream (https://github.com/Nebulaworks/nix-garage/runs/6597588623):

```
$ docker run -it --rm nebulaworks/magic-wormhole-mailbox@sha256:db0e29aea208e67026237188ac7e9be0a151f79b6ef3385e4357bb9f66faed51
Unable to find image 'nebulaworks/magic-wormhole-mailbox@sha256:db0e29aea208e67026237188ac7e9be0a151f79b6ef3385e4357bb9f66faed51' locally
docker.io/nebulaworks/magic-wormhole-mailbox@sha256:db0e29aea208e67026237188ac7e9be0a151f79b6ef3385e4357bb9f66faed51: Pulling from nebulaworks/magic-wormhole-mailbox
ad6d972690e5: Pull complete 
Digest: sha256:db0e29aea208e67026237188ac7e9be0a151f79b6ef3385e4357bb9f66faed51
Status: Downloaded newer image for nebulaworks/magic-wormhole-mailbox@sha256:db0e29aea208e67026237188ac7e9be0a151f79b6ef3385e4357bb9f66faed51
2022-05-28T00:02:26+0000 [-] RLIMIT_NOFILE.soft was 1048576, leaving it alone
2022-05-28T00:02:26+0000 [-] populating new database with schema channel v1
2022-05-28T00:02:26+0000 [-] populating new database with schema usage v2
2022-05-28T00:02:26+0000 [-] not blurring access times
2022-05-28T00:02:26+0000 [-] websocket listening on ws://HOSTNAME:PORT/v1
2022-05-28T00:02:26+0000 [-] Wormhole relay server running
2022-05-28T00:02:26+0000 [-] not blurring access times
2022-05-28T00:02:26+0000 [-] beginning app prune
2022-05-28T00:02:26+0000 [-] app prune ends, 0 apps
2022-05-28T00:02:26+0000 [-] PrivacyEnhancedSite starting on 4000
2022-05-28T00:02:26+0000 [wormhole_mailbox_server.web.PrivacyEnhancedSite#info] Starting factory <wormhole_mailbox_server.web.PrivacyEnhancedSite object at 0x7fe915b9e1f0>
2022-05-28T00:02:26+0000 [twisted.application.runner._runner.Runner#info] Starting reactor...
```

- Echo master sha during the workflow: `Utilizing sha: d113661156581c835df4fe5521ffc64128772f18`

