### PR TITLE
[READY] - [dh/infra-issue-512] Adds pdf validation to term-apply

### DIFF
--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -3,20 +3,20 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "b9d129b6b626dfd81c36e4c555822f86f5e95b76";
+    rev = "ffab245d1c0f21700bfece040f0749f797b751fc";
     repo = "orion";
-    sha256 = "sha256:0483vyfrdc55cb1zda73za8ppjk5g7sljyjb0aj87f75qrgf4cv7";
+    sha256 = "sha256:1zvidyhvi9hdn3jl9lb98j1gs92f44n024y08l39vzkdg52g3wcw";
   };
 
 in
 buildGoModule rec {
   inherit src;
   pname = "term-apply-unstable";
-  version = "2022-05-17";
+  version = "2022-06-20";
 
   sourceRoot = "${src.name}/apps/term-apply";
 
-  vendorSha256 = "sha256-DA923aOtIvvzre6PFUwrnHwb0WMe67v3eqp0Ejm1ArI=";
+  vendorSha256 = "sha256-pZs/MQcCflfpJ820c1Genkk+kT8/2qqwS0bO8oQ3Utg=";
 
   ldflags = [
     "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.Commit=${src.rev}"


### PR DESCRIPTION
## Description

Fixes: #512 in infra

Adds file validity checking for both size and file type

## Previous Behavior
* Any uploaded file is accepted and uploaded to the s3 bucket

## New Behavior
* File size is checked to ensure it isn't too large (greater than 10MB) files any larger are invalid
* File contents are analyzed to ensure it is actually a valid PDF
* Any file that is flagged as invalid is not uploaded to s3 or saved to the uploads folder of the server
* When an upload fails, the user is notified when their last valid file was uploaded, or if they have never uploaded a valid file.

## Tests
* Two different files were uploaded: one plain text file and one pdf. Only the pdf was uploaded to s3
* A valid PDF that is greater than 10MB was uploaded and rejected immediately.
