### PR TITLE
[READY] - [dh/infra-issue-524/539] term-apply ssh host key consistency AND SIGSEGV with server error

### DIFF
--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -3,20 +3,20 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "ffab245d1c0f21700bfece040f0749f797b751fc";
+    rev = "d446f5088690f2e824aeeca5b8bf32ad50236cb2";
     repo = "orion";
-    sha256 = "sha256:1zvidyhvi9hdn3jl9lb98j1gs92f44n024y08l39vzkdg52g3wcw";
+    sha256 = "sha256:0y0krlzrpgrlrm6rg2s7zims3s0g6jwqjj8r4hyp8f9p3z52liy0";
   };
 
 in
 buildGoModule rec {
   inherit src;
   pname = "term-apply-unstable";
-  version = "2022-06-20";
+  version = "2022-07-05";
 
   sourceRoot = "${src.name}/apps/term-apply";
 
-  vendorSha256 = "sha256-pZs/MQcCflfpJ820c1Genkk+kT8/2qqwS0bO8oQ3Utg=";
+  vendorSha256 = "sha256-OX7aXXnFLNCsux+sHzOkwxx0zBe7XwbHhWIgXRQtUYU=";
 
   ldflags = [
     "-X github.com/nebulaworks/orion/apps/term-apply/pkg/version.Commit=${src.rev}"


### PR DESCRIPTION
## Description

Fixes: [infra issue #524](https://gitlab.com/nebulaworks/eng/infra/-/issues/524) and [infra issue #539](https://gitlab.com/nebulaworks/eng/infra/-/issues/539)

Brief description of the PR

## Previous Behavior
* Each time a new RE of term-apply was spun up, a new SSH host key would be generated, leading to inconsistency of host keys.
* Fatal error would occur if the `TA_HOST_KEY_PATH` contained a public key with no corresponding private key

## New Behavior
* Host Keys can be downloaded from SSM SecureString Parameters specified by the `TA_SSM_HOST_KEY_PARAM` env variable.
* The location of host keys can be specified by the `TA_HOST_KEY_PATH` env variable.
  * This location serves as the target download location for the key specified by `TA_SSM_HOST_KEY_PARAM` should a parameter be provided, the local location term-apply will look for a preexisting host key, and the location where a host key will generate if none is found at that location.
  * If a new host key is generated, a corresponding public key will also be generated. This public key is not necessary for TA to function and therefore is not downloaded if a parameter is provided
* Fatal error is handled gracefully

## Tests
1. Started TA with neither new variable set: startup behavior matched the previous behavior exactly
2. Started TA with just `TA_SSM_HOST_KEY_PARAM` set correctly: TA successfully downloaded the host key and started the server without issue. The host key was downloaded to the default location. This worked correctly with and without a preexisting .ssh directory
3. Started TA with just `TA_HOST_KEY_PATH`: TA successfully generated and used a new host key at the specified path
4. Started TA with both new variables set: TA successfully downloaded the host key to the specified location and booted correctly
5. Started TA with `TA_SSM_HOST_KEY_PARAM` set incorrectly: TA failed to start. Any preexisting host keys at the specified location were left intact. If no file existed before, none were created.
6. Ran TA with no SSM Param env variable and the standard host key path while having a public key with no corresponding private key: TA Exited with error code 1 and logged the error