### PR TITLE
[READY] [infra-529] Set new version info for term-apply

### DIFF
--- a/pkgs/term-apply/default.nix
+++ b/pkgs/term-apply/default.nix
@@ -3,16 +3,16 @@
 let
   src = fetchFromGitHub {
     owner = "nebulaworks";
-    rev = "4367a22f2ebfcfff18d51f9aa4d8018b1512cdf8";
+    rev = "740f58c47881608c6db815dc99e88ad65588b0eb";
     repo = "orion";
-    sha256 = "sha256:0fbcnvhsd90v7w25288y4x10ynkdiq21v4x183v9m69dc0a9xygd";
+    sha256 = "sha256:1vydx2xdifp4msnyrnwyf23nhglf98kl5igycnp40h50k2rmahry";
   };
 
 in
 buildGoModule rec {
   inherit src;
   pname = "term-apply-unstable";
-  version = "2022-08-08";
+  version = "2022-09-22";
 
   sourceRoot = "${src.name}/apps/term-apply";
 


### PR DESCRIPTION
## Description of PR

This updates the version of term-apply to the version from the corresponding branch in orion.

## Previous Behavior
There was a race condition with reading and writing to DynamoDB.

## New Behavior
A given applicant's record is locked while it's being updated.

## Tests
I ran a build locally and it completed successfully.
