### PR TITLE
[READY] - rm deprecated buildFlagsArray in tf config inspect pkg

### DIFF
--- a/pkgs/terraform-config-inspect/default.nix
+++ b/pkgs/terraform-config-inspect/default.nix
@@ -14,8 +14,7 @@ buildGoModule rec {
 
   vendorSha256 = "14r0q13hi8x7h6kkb26i8v1ialwk86ykgmn53i7874w1kvmzx2hg";
 
-  buildFlagsArray = [
-    "-ldflags="
+  ldflags = [
     "-s"
     "-w"
   ];


### PR DESCRIPTION
## Description of PR

Relates to: https://github.com/Nebulaworks/nix-garage/pull/68

`buildFlagsArray` has been deprecated for some time. Moving the last reference of this in pkgs to `ldflags`

## Previous Behavior
- Warning received anytime overlay is consumed due to `buildFlagsArray`

## New Behavior
- Warning gone since all go pkgs leverage `ldflags`

## Tests
- Build from the toplevel of this repo:

```
$ nix-build -A pkgs.terraform-config-inspect
$ ./result/bin/terraform-config-inspect -v
unknown shorthand flag: 'v' in -v
Usage of ./result/bin/terraform-config-inspect:
      --json   produce JSON-formatted output
unknown shorthand flag: 'v' in -v
```
> not really any flags due to the nature of this codebase