### PR TITLE
[READY] - update workflows runs-on to 22.04

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   upstream_nixpkgs:
     name: 'Build images off master'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     # Utilizing nixos/nix docker image v2.7.0
     container:
       image: nixos/nix@sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce

--- a/.github/workflows/lint-nix.yml
+++ b/.github/workflows/lint-nix.yml
@@ -11,7 +11,7 @@ on: pull_request
 jobs:
   linter:
     name: Run nixpkgs-fmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # Utilizing nixos/nix docker image v2.7.0
     container:

--- a/.github/workflows/publish_imgs.yml
+++ b/.github/workflows/publish_imgs.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   verify:
     name: Verify commenter
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # Checks if the comment contains the word 'publish as well as if the comment was made in a PR
     if: >


### PR DESCRIPTION
## Description of PR

Fixes: #81

Ensure we are running GHA on vms that are supported.

## Previous Behavior
- GHA workflows were referring to 18.04

## New Behavior
- GHA workflows are referring to 22.04

## Tests
- Triggered the daily run: https://github.com/Nebulaworks/nix-garage/actions/runs/4706086521